### PR TITLE
[feat/kakao-oauth] 카카오 로그인 구현

### DIFF
--- a/src/main/java/com/sideproject/shoescream/member/controller/MemberController.java
+++ b/src/main/java/com/sideproject/shoescream/member/controller/MemberController.java
@@ -1,18 +1,19 @@
 package com.sideproject.shoescream.member.controller;
 
 import com.sideproject.shoescream.global.dto.response.Response;
+import com.sideproject.shoescream.member.dto.KaKaoTokenDto;
 import com.sideproject.shoescream.member.dto.request.MemberFindMemberInfoRequest;
 import com.sideproject.shoescream.member.dto.request.MemberSignInRequest;
 import com.sideproject.shoescream.member.dto.request.MemberSignUpRequest;
 import com.sideproject.shoescream.member.dto.response.MemberResponse;
 import com.sideproject.shoescream.member.dto.response.MemberSignInResponse;
+import com.sideproject.shoescream.member.entity.Member;
 import com.sideproject.shoescream.member.service.EmailService;
 import com.sideproject.shoescream.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,5 +50,11 @@ public class MemberController {
     @PostMapping("/signin/find-password")
     public Response<String> findMemberPassword(@RequestBody MemberFindMemberInfoRequest memberFindMemberInfoRequest) {
         return Response.success(emailService.sendRandomPasswordMail(memberFindMemberInfoRequest));
+    }
+
+    @GetMapping("/oauth/token")
+    public Response<Member> kakaoLogin(@RequestParam("code") String code) {
+        KaKaoTokenDto kaKaoTokenDto = memberService.getKakaoAccessToken(code);
+        return Response.success(memberService.kakaoLogin(kaKaoTokenDto.getAccess_token()));
     }
 }

--- a/src/main/java/com/sideproject/shoescream/member/dto/KaKaoTokenDto.java
+++ b/src/main/java/com/sideproject/shoescream/member/dto/KaKaoTokenDto.java
@@ -1,0 +1,13 @@
+package com.sideproject.shoescream.member.dto;
+
+import lombok.Data;
+
+@Data
+public class KaKaoTokenDto {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private int refresh_token_expires_in;
+    private String scope;
+}

--- a/src/main/java/com/sideproject/shoescream/member/dto/KakaoProfile.java
+++ b/src/main/java/com/sideproject/shoescream/member/dto/KakaoProfile.java
@@ -1,0 +1,16 @@
+package com.sideproject.shoescream.member.dto;
+
+import lombok.Data;
+
+@Data
+public class KakaoProfile {
+    public Long id;
+    public String connected_at;
+    public KakaoAccount kakaoAccount;
+
+    @Data
+    public class KakaoAccount {
+        public String nickname;
+        public String email;
+    }
+}

--- a/src/main/java/com/sideproject/shoescream/member/service/MemberService.java
+++ b/src/main/java/com/sideproject/shoescream/member/service/MemberService.java
@@ -1,6 +1,10 @@
 package com.sideproject.shoescream.member.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sideproject.shoescream.global.exception.ErrorCode;
+import com.sideproject.shoescream.member.dto.KaKaoTokenDto;
+import com.sideproject.shoescream.member.dto.KakaoProfile;
 import com.sideproject.shoescream.member.dto.request.MemberFindMemberInfoRequest;
 import com.sideproject.shoescream.member.dto.request.MemberSignInRequest;
 import com.sideproject.shoescream.member.dto.request.MemberSignUpRequest;
@@ -12,11 +16,18 @@ import com.sideproject.shoescream.member.repository.MemberRepository;
 import com.sideproject.shoescream.member.util.JwtTokenUtil;
 import com.sideproject.shoescream.member.util.MemberMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +36,12 @@ public class MemberService implements UserDetailsService {
     private final MemberRepository memberRepository;
     private final JwtTokenUtil jwtTokenUtil;
     private final BCryptPasswordEncoder encoder;
+    public static final String KAKAO_CLIENT_ID = "cb87d198bac8bdd63f6684692e3d827c";
+    public static final String KAKAO_CLIENT_SECRET = "HduZ5Cvc9TGDlLEgdWiJEfBeRdQTbXHa";
+    public static final String KAKAO_REDIRECT_URI = "http://localhost:8080/login/oauth2/code/kakao";
+    public static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    public static final String KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
 
     @Override
     public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
@@ -42,7 +59,6 @@ public class MemberService implements UserDetailsService {
                         encoder.encode(memberSignUpRequest.password()))));
     }
 
-
     public MemberSignInResponse signIn(MemberSignInRequest memberSignInRequest) {
         Member member = memberRepository.findByMemberId(memberSignInRequest.memberId())
                 .orElseThrow(
@@ -57,6 +73,88 @@ public class MemberService implements UserDetailsService {
 
         return MemberMapper.toSignInResponse(MemberMapper.toMemberResponse(member),
                 MemberMapper.toTokenResponse(accessToken, refreshToken));
+    }
+
+    public Member kakaoLogin(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        KakaoProfile kakaoProfile = getKakaoProfile(kakaoAccessToken);
+        Member member = memberRepository.findByEmail(kakaoProfile.getKakaoAccount().getEmail()).orElse(null);
+
+        // 처음 로그인일 경우
+        if (member == null) {
+            member = Member.builder()
+                    .id(kakaoProfile.getId())
+                    .email(kakaoProfile.getKakaoAccount().getEmail())
+                    .name(kakaoProfile.getKakaoAccount().getNickname())
+                    .build();
+            memberRepository.save(member);
+        }
+        return member;
+    }
+
+    public KaKaoTokenDto getKakaoAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // Http Response Body 객체 생성
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", KAKAO_CLIENT_ID);
+        params.add("redirect_uri", KAKAO_REDIRECT_URI);
+        params.add("code", code);
+        params.add("client_secret", KAKAO_CLIENT_SECRET);
+
+        // Header + Body
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<String> accessTokenResponse = restTemplate.exchange(
+                KAKAO_TOKEN_URL,
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        //Json Parsing
+        ObjectMapper objectMapper = new ObjectMapper();
+        KaKaoTokenDto kakaoTokenDto = null;
+        try {
+            kakaoTokenDto = objectMapper.readValue(accessTokenResponse.getBody(), KaKaoTokenDto.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return kakaoTokenDto;
+    }
+
+    public KakaoProfile getKakaoProfile(String kakaoAccessToken) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + kakaoAccessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(headers);
+
+        // POST 방식으로 API 서버에 요청 후 response 받아옴
+        ResponseEntity<String> memberInfoResponse = restTemplate.exchange(
+                KAKAO_USER_INFO_URI,
+                HttpMethod.POST,
+                kakaoProfileRequest,
+                String.class
+        );
+
+        // Json Parsing
+        ObjectMapper objectMapper = new ObjectMapper();
+        KakaoProfile kakaoProfile = null;
+        try {
+            kakaoProfile = objectMapper.readValue(memberInfoResponse.getBody(),
+                    KakaoProfile.class);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return kakaoProfile;
     }
 
     public String findMemberId(MemberFindMemberInfoRequest memberFindMemberInfoRequest) {


### PR DESCRIPTION
#9 Rest API를 이용한 카카오 로그인, 회원가입 기능 구현에 대한 pr입니다.

**동작 흐름**
1. 클라이언트에서 GET 요청으로 카카오 인가 코드를 받아온다.
2. 전달 받은 인가 코드로 카카오 엑세스 토큰을 발급 받는다.
3. 엑세스 토큰으로 회원정보를 조회하고 DB에 없는 유저라면 회원가입, 있는 유저라면 로그인을 한다.
4. 프론트에게 JWT 토큰을 넘겨준다. (적용 x)

클라이언트에서 카카오 인가 코드를 받는 컨트롤러
```
@GetMapping("/oauth/token")
public Response<Member> kakaoLogin(@RequestParam("code") String code) {
    KaKaoTokenDto kaKaoTokenDto = memberService.getKakaoAccessToken(code);
    return Response.success(memberService.kakaoLogin(kaKaoTokenDto.getAccess_token()));
}
```
