### PR TITLE
[feat/bid] 상품 구매 + 결제 구현

### DIFF
--- a/src/main/java/com/sideproject/shoescream/bid/constant/BidStatus.java
+++ b/src/main/java/com/sideproject/shoescream/bid/constant/BidStatus.java
@@ -4,8 +4,8 @@ import lombok.Getter;
 
 @Getter
 public enum BidStatus {
-    WAITING_MATCHING("waitingMating"),
-    COMPLETE_MATCHING("completeMating"),
+    WAITING_MATCHING("waiting_matching"),
+    COMPLETE_MATCHING("complete_matching"),
     CANCEL("cancel");
 
     private final String bidStatus;

--- a/src/main/java/com/sideproject/shoescream/bid/constant/BidStatus.java
+++ b/src/main/java/com/sideproject/shoescream/bid/constant/BidStatus.java
@@ -6,8 +6,7 @@ import lombok.Getter;
 public enum BidStatus {
     WAITING_MATCHING("waitingMating"),
     COMPLETE_MATCHING("completeMating"),
-    NONE("none"),
-    CANCEL("cancle");
+    CANCEL("cancel");
 
     private final String bidStatus;
 

--- a/src/main/java/com/sideproject/shoescream/bid/constant/BidType.java
+++ b/src/main/java/com/sideproject/shoescream/bid/constant/BidType.java
@@ -4,10 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum BidType {
+
     SELL_BID("sellBid"),
-    SELL_NOW("sellNow"),
-    BUY_BID("buyBid"),
-    BUY_NOW("buyNow");
+    BUY_BID("buyBid");
 
     private final String bidType;
 
@@ -15,4 +14,4 @@ public enum BidType {
         this.bidType = bidType;
     }
 
-}
+    }

--- a/src/main/java/com/sideproject/shoescream/bid/constant/BidType.java
+++ b/src/main/java/com/sideproject/shoescream/bid/constant/BidType.java
@@ -5,8 +5,10 @@ import lombok.Getter;
 @Getter
 public enum BidType {
 
-    SELL_BID("sellBid"),
-    BUY_BID("buyBid");
+    SELL_BID("sell_bid"),
+    SELL_NOW("sell_now"),
+    BUY_BID("buy_bid"),
+    BUY_NOW("buy_now");
 
     private final String bidType;
 

--- a/src/main/java/com/sideproject/shoescream/bid/constant/DealStatus.java
+++ b/src/main/java/com/sideproject/shoescream/bid/constant/DealStatus.java
@@ -4,10 +4,10 @@ import lombok.Getter;
 
 @Getter
 public enum DealStatus {
-    WAITING_DEPOSIT("pending"),
-    COMPLETE_DEPOSIT("pending"),
-    FAIL_DEAL("finishing"),
-    SUCCESS_DEAL("finishing");
+    WAITING_DEPOSIT("waiting_deposit"),
+    COMPLETE_DEPOSIT("complete_deposit"),
+    FAIL_DEAL("fail_deal"),
+    SUCCESS_DEAL("success_deal");
 
     private final String dealStatus;
 

--- a/src/main/java/com/sideproject/shoescream/bid/constant/DealStatus.java
+++ b/src/main/java/com/sideproject/shoescream/bid/constant/DealStatus.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 public enum DealStatus {
     WAITING_DEPOSIT("pending"),
     COMPLETE_DEPOSIT("pending"),
-    WAITING_TRANSFER("pending"),
-    COMPLETE_TRANSFER("pending"),
     FAIL_DEAL("finishing"),
     SUCCESS_DEAL("finishing");
 

--- a/src/main/java/com/sideproject/shoescream/bid/controller/BidController.java
+++ b/src/main/java/com/sideproject/shoescream/bid/controller/BidController.java
@@ -6,6 +6,7 @@ import com.sideproject.shoescream.bid.dto.response.*;
 import com.sideproject.shoescream.bid.service.BidService;
 import com.sideproject.shoescream.global.dto.response.Response;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,25 +15,26 @@ public class BidController {
 
     private final BidService bidService;
 
+    @GetMapping("/buy/{productNumber}")
+    public Response<BuyingProductInfoResponse> getBuyingProductInfo(@PathVariable Long productNumber, @RequestParam String size, Authentication authentication) {
+        return Response.success(bidService.getBuyingProductInfo(productNumber, size, authentication));
+    }
+
+    @PostMapping("/buy")
+    public Response<BuyingBidResponse> buyingBid(@RequestBody BuyingBidRequest buyingBidRequest, Authentication authentication) {
+        return Response.success(bidService.buyingBid(buyingBidRequest, authentication));
+    }
+
     @GetMapping("/sell/{productNumber}")
     public Response<SellingProductInfoResponse> getSellingProductInfo(@PathVariable Long productNumber, @RequestParam String size) {
         return Response.success(bidService.getSellingProductInfo(productNumber, size));
     }
 
-    @PostMapping("/sell-bid")
-    public Response<SellingBidResponse> sellingBid(@RequestBody SellingBidRequest sellingBidRequest) {
-        return Response.success(bidService.sellingBid(sellingBidRequest));
+    @PostMapping("/sell")
+    public Response<SellingBidResponse> sellingBid(@RequestBody SellingBidRequest sellingBidRequest, Authentication authentication) {
+        return Response.success(bidService.sellingBid(sellingBidRequest, authentication));
     }
 
-    @GetMapping("/buy/{productNumber}")
-    public Response<BuyingProductInfoResponse> getBuyingProductInfo(@PathVariable Long productNumber, @RequestParam String size) {
-        return Response.success(bidService.getBuyingProductInfo(productNumber, size));
-    }
-
-    @PostMapping("/buy-bid")
-    public Response<BuyingBidResponse> buyingBid(@RequestBody BuyingBidRequest buyingBidRequest) {
-        return Response.success(bidService.buyingBid(buyingBidRequest));
-    }
 
     @GetMapping("/bid-history")
     public Response<BidHistoryResponse> getBidHistory(@RequestParam String productNumber, @RequestParam String size) {

--- a/src/main/java/com/sideproject/shoescream/bid/entity/Bid.java
+++ b/src/main/java/com/sideproject/shoescream/bid/entity/Bid.java
@@ -25,20 +25,20 @@ public class Bid {
     private long id;
 
     @ManyToOne
-    @JoinColumn(name = "product_number")
+    @JoinColumn(name = "product_number", nullable = false)
     private Product product;
 
     @ManyToOne
-    @JoinColumn(name = "member_number")
+    @JoinColumn(name = "member_number", nullable = false)
     private Member member;
 
-    @Column(name = "bid_product_size")
+    @Column(name = "bid_product_size", nullable = false)
     private String size;
 
-    @Column(name = "bid_price")
+    @Column(name = "bid_price", nullable = false)
     private int bidPrice;
 
-    @Column(name = "created_at")
+    @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
     @Column(name = "bid_deadline")

--- a/src/main/java/com/sideproject/shoescream/bid/entity/Deal.java
+++ b/src/main/java/com/sideproject/shoescream/bid/entity/Deal.java
@@ -23,13 +23,15 @@ public class Deal {
     @Column(name = "deal_number")
     private long id;
 
+    @Column(name = "buyer_number")
+    private long buyerNumber;
+
+    @Column(name = "seller_number")
+    private long sellerNumber;
+
     @ManyToOne
     @JoinColumn(name = "product_number")
     private Product product;
-
-    @ManyToOne
-    @JoinColumn(name = "member_number")
-    private Member member;
 
     @Column(name = "deal_size")
     private String size;

--- a/src/main/java/com/sideproject/shoescream/bid/repository/BidRepository.java
+++ b/src/main/java/com/sideproject/shoescream/bid/repository/BidRepository.java
@@ -1,14 +1,21 @@
 package com.sideproject.shoescream.bid.repository;
 
+import com.sideproject.shoescream.bid.constant.BidType;
 import com.sideproject.shoescream.bid.entity.Bid;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BidRepository extends JpaRepository<Bid, Long> {
 
     @Query("select b from Bid b where b.member.memberNumber = :memberNumber")
     List<Bid> findByMemberNumber(@Param("memberNumber") Long memberNumber);
+
+    @Query("select b from Bid b where b.product.id =:productNumber and b.bidPrice =:bidPrice and b.bidType =:bidType order by b.createdAt")
+    Optional<Bid> findTargetBidOne(@Param("productNumber") Long productNumber,
+                                @Param("bidPrice") int bidPrice,
+                                @Param("bidType") BidType bidType);
 }

--- a/src/main/java/com/sideproject/shoescream/bid/repository/DealRepository.java
+++ b/src/main/java/com/sideproject/shoescream/bid/repository/DealRepository.java
@@ -11,6 +11,6 @@ public interface DealRepository extends JpaRepository<Deal, Long> {
 
     List<Deal> findByProductId(Long productNumber);
 
-    @Query("select d from Deal d where d.member.memberNumber = :memberNumber")
+    @Query("select d from Deal d where d.buyerNumber=:memberNumber or d.sellerNumber=:memberNumber")
     List<Deal> findByMemberNumber(@Param("memberNumber") Long memberNumber);
 }

--- a/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
+++ b/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
@@ -1,19 +1,32 @@
 package com.sideproject.shoescream.bid.service;
 
+import com.sideproject.shoescream.bid.constant.BidStatus;
 import com.sideproject.shoescream.bid.constant.BidType;
+import com.sideproject.shoescream.bid.constant.DealStatus;
 import com.sideproject.shoescream.bid.dto.request.BuyingBidRequest;
 import com.sideproject.shoescream.bid.dto.request.SellingBidRequest;
 import com.sideproject.shoescream.bid.dto.response.*;
+import com.sideproject.shoescream.bid.entity.Bid;
 import com.sideproject.shoescream.bid.repository.BidRepository;
+import com.sideproject.shoescream.bid.repository.DealRepository;
 import com.sideproject.shoescream.bid.util.BidMapper;
+import com.sideproject.shoescream.bid.util.DealMapper;
+import com.sideproject.shoescream.global.exception.ErrorCode;
+import com.sideproject.shoescream.member.entity.Member;
+import com.sideproject.shoescream.member.exception.MemberNotFoundException;
+import com.sideproject.shoescream.member.repository.MemberRepository;
 import com.sideproject.shoescream.product.entity.Product;
 import com.sideproject.shoescream.product.entity.ProductOption;
 import com.sideproject.shoescream.product.repository.ProductImageRepository;
 import com.sideproject.shoescream.product.repository.ProductOptionRepository;
 import com.sideproject.shoescream.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,46 +36,17 @@ public class BidService {
     private final ProductRepository productRepository;
     private final ProductOptionRepository productOptionRepository;
     private final ProductImageRepository productImageRepository;
+    private final DealRepository dealRepository;
+    private final MemberRepository memberRepository;
 
     public SellingProductInfoResponse getSellingProductInfo(Long productNumber, String size) {
         ProductOption product = productOptionRepository.findByProductIdAndSize(productNumber, size);
         return BidMapper.toSellingProductInfoResponse(product);
     }
 
-    @Transactional
-    public SellingBidResponse sellingBid(SellingBidRequest sellingBidRequest) {
-        ProductOption productOption = productOptionRepository.findByProductId(sellingBidRequest.productNumber());
-
-        if (sellingBidRequest.price() == productOption.getHighestPrice()) {
-            return BidMapper.toSellingBidResponse(bidRepository.save(
-                    BidMapper.toSellingBid(
-                            sellingBidRequest, productOption, BidType.SELL_NOW)));
-
-        }
-
-        return BidMapper.toSellingBidResponse(bidRepository.save(
-                BidMapper.toSellingBid(
-                        sellingBidRequest, productOption, BidType.SELL_BID)));
-    }
-
-    public BuyingProductInfoResponse getBuyingProductInfo(Long productNumber, String size) {
+    public BuyingProductInfoResponse getBuyingProductInfo(Long productNumber, String size, Authentication authentication) {
         ProductOption product = productOptionRepository.findByProductIdAndSize(productNumber, size);
         return BidMapper.toBuyingProductInfoResponse(product);
-    }
-
-    @Transactional
-    public BuyingBidResponse buyingBid(BuyingBidRequest buyingBidRequest) {
-        ProductOption productOption = productOptionRepository.findByProductId(buyingBidRequest.productNumber());
-
-        if (buyingBidRequest.price() == productOption.getLowestPrice()) {
-            return BidMapper.toBuyingBidResponse(bidRepository.save(
-                    BidMapper.toBuyingBid(
-                            buyingBidRequest, productOption, BidType.BUY_NOW)));
-        }
-
-        return BidMapper.toBuyingBidResponse(bidRepository.save(
-                BidMapper.toBuyingBid(
-                        buyingBidRequest, productOption, BidType.BUY_BID)));
     }
 
     public BidHistoryResponse getBidHistory(String productNumber, String size) {
@@ -70,5 +54,41 @@ public class BidService {
                 .orElseThrow(() -> new RuntimeException());
 
         return BidMapper.toBidHistoryResponse(product, size);
+    }
+
+    @Transactional
+    public SellingBidResponse sellingBid(SellingBidRequest sellingBidRequest, Authentication authentication) {
+        Member member = memberRepository.findByMemberId(authentication.getName())
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        ProductOption productOption = productOptionRepository.findByProductIdAndSize(sellingBidRequest.productNumber(), sellingBidRequest.size());
+        Optional<Bid> buyBid = bidRepository.findTargetBidOne(productOption.getProduct().getId(), sellingBidRequest.price(), BidType.BUY_BID);
+
+        if (buyBid.isEmpty()) {
+            return BidMapper.toSellingBidResponse(bidRepository.save(
+                    BidMapper.toSellingBid(
+                            sellingBidRequest, member, productOption, BidType.SELL_BID)));
+        }
+
+        buyBid.get().setBidStatus(BidStatus.COMPLETE_MATCHING);
+        dealRepository.save(DealMapper.sellingBidToDeal(sellingBidRequest, productOption, buyBid.get(), member.getMemberNumber(), DealStatus.WAITING_DEPOSIT));
+        return BidMapper.toSellingBidResponse(BidMapper.toSellingBid(sellingBidRequest, member, productOption, BidType.SELL_NOW));
+    }
+
+    @Transactional
+    public BuyingBidResponse buyingBid(BuyingBidRequest buyingBidRequest, Authentication authentication) {
+        Member member = memberRepository.findByMemberId(authentication.getName())
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        ProductOption productOption = productOptionRepository.findByProductIdAndSize(buyingBidRequest.productNumber(), buyingBidRequest.size());
+        Optional<Bid> sellBid = bidRepository.findTargetBidOne(productOption.getProduct().getId(), buyingBidRequest.price(), BidType.SELL_BID);
+
+        if (sellBid.isEmpty()) {
+            return BidMapper.toBuyingBidResponse(bidRepository.save(
+                    BidMapper.toBuyingBid(
+                            buyingBidRequest, member, productOption, BidType.BUY_BID)));
+        }
+
+        sellBid.get().setBidStatus(BidStatus.COMPLETE_MATCHING);
+        dealRepository.save(DealMapper.buyingBidToDeal(buyingBidRequest, productOption, sellBid.get(), member.getMemberNumber(), DealStatus.WAITING_DEPOSIT));
+        return BidMapper.toBuyingBidResponse(BidMapper.toBuyingBid(buyingBidRequest, member, productOption, BidType.BUY_NOW));
     }
 }

--- a/src/main/java/com/sideproject/shoescream/bid/util/BidMapper.java
+++ b/src/main/java/com/sideproject/shoescream/bid/util/BidMapper.java
@@ -6,6 +6,7 @@ import com.sideproject.shoescream.bid.dto.request.BuyingBidRequest;
 import com.sideproject.shoescream.bid.dto.request.SellingBidRequest;
 import com.sideproject.shoescream.bid.dto.response.*;
 import com.sideproject.shoescream.bid.entity.Bid;
+import com.sideproject.shoescream.member.entity.Member;
 import com.sideproject.shoescream.product.entity.Product;
 import com.sideproject.shoescream.product.entity.ProductOption;
 
@@ -25,10 +26,11 @@ public class BidMapper {
                 .build();
     }
 
-    public static Bid toSellingBid(SellingBidRequest sellingBidRequest, ProductOption productOption, BidType bidType) {
+    public static Bid toSellingBid(SellingBidRequest sellingBidRequest, Member member, ProductOption productOption, BidType bidType) {
         LocalDateTime now = LocalDateTime.now();
         return Bid.builder()
                 .product(productOption.getProduct())
+                .member(member)
                 .size(sellingBidRequest.size())
                 .bidPrice(sellingBidRequest.price())
                 .createdAt(now)
@@ -57,10 +59,11 @@ public class BidMapper {
                 .build();
     }
 
-    public static Bid toBuyingBid(BuyingBidRequest buyingBidRequest, ProductOption productOption, BidType bidType) {
+    public static Bid toBuyingBid(BuyingBidRequest buyingBidRequest, Member member, ProductOption productOption, BidType bidType) {
         LocalDateTime now = LocalDateTime.now();
         return Bid.builder()
                 .product(productOption.getProduct())
+                .member(member)
                 .size(buyingBidRequest.size())
                 .bidPrice(buyingBidRequest.price())
                 .createdAt(now)

--- a/src/main/java/com/sideproject/shoescream/bid/util/DealMapper.java
+++ b/src/main/java/com/sideproject/shoescream/bid/util/DealMapper.java
@@ -1,13 +1,18 @@
 package com.sideproject.shoescream.bid.util;
 
 import com.sideproject.shoescream.bid.constant.DealStatus;
+import com.sideproject.shoescream.bid.dto.request.BuyingBidRequest;
+import com.sideproject.shoescream.bid.dto.request.SellingBidRequest;
 import com.sideproject.shoescream.bid.dto.response.DealHistoryResponse;
 import com.sideproject.shoescream.bid.dto.response.DealResponse;
 import com.sideproject.shoescream.bid.dto.response.QuoteResponse;
+import com.sideproject.shoescream.bid.entity.Bid;
 import com.sideproject.shoescream.bid.entity.Deal;
 import com.sideproject.shoescream.product.entity.Product;
+import com.sideproject.shoescream.product.entity.ProductOption;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -21,6 +26,30 @@ public class DealMapper {
                 .size(deal.getSize())
                 .price(deal.getPrice())
                 .tradedAt(deal.getTradedAt())
+                .build();
+    }
+
+    public static Deal buyingBidToDeal(BuyingBidRequest buyingBidRequest, ProductOption productOption, Bid bid, long buyerNumber, DealStatus dealStatus) {
+        return Deal.builder()
+                .buyerNumber(buyerNumber)
+                .sellerNumber(bid.getMember().getMemberNumber())
+                .product(productOption.getProduct())
+                .size(buyingBidRequest.size())
+                .price(buyingBidRequest.price())
+                .dealStatus(dealStatus)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public static Deal sellingBidToDeal(SellingBidRequest sellingBidRequest, ProductOption productOption, Bid bid, long sellerNumber, DealStatus dealStatus) {
+        return Deal.builder()
+                .buyerNumber(bid.getMember().getMemberNumber())
+                .sellerNumber(sellerNumber)
+                .product(productOption.getProduct())
+                .size(sellingBidRequest.size())
+                .price(sellingBidRequest.price())
+                .dealStatus(dealStatus)
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/com/sideproject/shoescream/member/service/MemberService.java
+++ b/src/main/java/com/sideproject/shoescream/member/service/MemberService.java
@@ -167,15 +167,15 @@ public class MemberService implements UserDetailsService {
     }
 
     private List<Bid> filterMyBuyingBiddingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Bid> myBiddingHistory = bidRepository.findByMemberNumber(member.getMemberNumber());
+        List<Bid> myBuyingBiddingHistory = bidRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null & endDate == null) {
-            return myBiddingHistory.stream()
+            return myBuyingBiddingHistory.stream()
                     .filter(bid -> bid.getBidType().getBidType().equals(BidType.BUY_BID.getBidType()))
                     .filter(bid -> bid.getBidStatus().getBidStatus().equals(BidStatus.WAITING_MATCHING.getBidStatus()))
                     .toList();
         }
 
-        return myBiddingHistory.stream()
+        return myBuyingBiddingHistory.stream()
                 .filter(bid -> bid.getBidType().getBidType().equals(BidType.BUY_BID.getBidType()))
                 .filter(bid -> bid.getBidStatus().getBidStatus().equals(BidStatus.WAITING_MATCHING.getBidStatus()))
                 .filter(bid -> bid.getCreatedAt().toLocalDate().isAfter(startDate) &&
@@ -185,15 +185,15 @@ public class MemberService implements UserDetailsService {
 
 
     private List<Deal> filterMyBuyingPendingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Deal> myPendingHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
+        List<Deal> myBuyingPendingHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null && endDate == null) {
-            return myPendingHistory.stream()
-                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_DEPOSIT.getDealStatus()))
-                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_DEPOSIT.getDealStatus()))
+            return myBuyingPendingHistory.stream()
+                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_TRANSFER.getDealStatus()))
+                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_TRANSFER.getDealStatus()))
                     .toList();
         }
 
-        return myPendingHistory.stream()
+        return myBuyingPendingHistory.stream()
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_TRANSFER.getDealStatus()))
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_TRANSFER.getDealStatus()))
                 .filter(deal -> deal.getCreatedAt().toLocalDate().isAfter(startDate) &&
@@ -202,15 +202,15 @@ public class MemberService implements UserDetailsService {
     }
 
     private List<Deal> filterMyBuyingFinishedByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Deal> myFinishedHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
+        List<Deal> myBuyingFinishedHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null && endDate == null) {
-            return myFinishedHistory.stream()
+            return myBuyingFinishedHistory.stream()
                     .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.SUCCESS_DEAL.getDealStatus()))
                     .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.FAIL_DEAL.getDealStatus()))
                     .toList();
         }
 
-        return myFinishedHistory.stream()
+        return myBuyingFinishedHistory.stream()
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.SUCCESS_DEAL.getDealStatus()))
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.FAIL_DEAL.getDealStatus()))
                 .filter(deal -> deal.getTradedAt().toLocalDate().isAfter(startDate) &&
@@ -219,15 +219,15 @@ public class MemberService implements UserDetailsService {
     }
 
     private List<Bid> filterMySellingBiddingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Bid> myBiddingHistory = bidRepository.findByMemberNumber(member.getMemberNumber());
+        List<Bid> mySellingBiddingHistory = bidRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null & endDate == null) {
-            return myBiddingHistory.stream()
+            return mySellingBiddingHistory.stream()
                     .filter(bid -> bid.getBidType().getBidType().equals(BidType.SELL_BID.getBidType()))
                     .filter(bid -> bid.getBidStatus().getBidStatus().equals(BidStatus.WAITING_MATCHING.getBidStatus()))
                     .toList();
         }
 
-        return myBiddingHistory.stream()
+        return mySellingBiddingHistory.stream()
                 .filter(bid -> bid.getBidType().getBidType().equals(BidType.SELL_BID.getBidType()))
                 .filter(bid -> bid.getBidStatus().getBidStatus().equals(BidStatus.WAITING_MATCHING.getBidStatus()))
                 .filter(bid -> bid.getCreatedAt().toLocalDate().isAfter(startDate) &&
@@ -236,15 +236,15 @@ public class MemberService implements UserDetailsService {
     }
 
     private List<Deal> filterMySellingPendingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Deal> myPendingHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
+        List<Deal> mySellingPendingHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null && endDate == null) {
-            return myPendingHistory.stream()
+            return mySellingPendingHistory.stream()
                     .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_DEPOSIT.getDealStatus()))
                     .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_DEPOSIT.getDealStatus()))
                     .toList();
         }
 
-        return myPendingHistory.stream()
+        return mySellingPendingHistory.stream()
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_DEPOSIT.getDealStatus()))
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_DEPOSIT.getDealStatus()))
                 .filter(deal -> deal.getCreatedAt().toLocalDate().isAfter(startDate) &&
@@ -253,15 +253,15 @@ public class MemberService implements UserDetailsService {
     }
 
     private List<Deal> filterMySellingFinishedByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Deal> myFinishedHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
+        List<Deal> mySellingFinishedHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null && endDate == null) {
-            return myFinishedHistory.stream()
+            return mySellingFinishedHistory.stream()
                     .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.SUCCESS_DEAL.getDealStatus()))
                     .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.FAIL_DEAL.getDealStatus()))
                     .toList();
         }
 
-        return myFinishedHistory.stream()
+        return mySellingFinishedHistory.stream()
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.SUCCESS_DEAL.getDealStatus()))
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.FAIL_DEAL.getDealStatus()))
                 .filter(deal -> deal.getTradedAt().toLocalDate().isAfter(startDate) &&

--- a/src/main/java/com/sideproject/shoescream/member/service/MemberService.java
+++ b/src/main/java/com/sideproject/shoescream/member/service/MemberService.java
@@ -193,8 +193,8 @@ public class MemberService implements UserDetailsService {
         }
 
         return myPendingHistory.stream()
-                .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_TRANSFER.getDealStatus()))
-                .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_TRANSFER.getDealStatus()))
+                .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_DEPOSIT.getDealStatus()))
+                .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_DEPOSIT.getDealStatus()))
                 .filter(deal -> deal.getCreatedAt().toLocalDate().isAfter(startDate) &&
                         deal.getCreatedAt().toLocalDate().isBefore(endDate))
                 .toList();

--- a/src/main/java/com/sideproject/shoescream/member/service/MemberService.java
+++ b/src/main/java/com/sideproject/shoescream/member/service/MemberService.java
@@ -130,18 +130,18 @@ public class MemberService implements UserDetailsService {
                 .orElseThrow(() -> new RuntimeException());
 
         if (status.equals("bidding")) {
-            List<Bid> buyingBids = filterMyBuyingBiddingByDateRange(startDate, endDate, member);
+            List<Bid> buyingBids = filterMyBiddingByDateRange(startDate, endDate, member, BidType.BUY_BID.getBidType());
             return buyingBids.stream()
                     .map(MemberMapper::toMyBuyingBidHistoryResponse)
                     .collect(Collectors.toList());
         } else if (status.equals("pending")) {
-            List<Deal> pendingDeals = filterMyBuyingPendingByDateRange(startDate, endDate, member);
+            List<Deal> pendingDeals = filterMyPendingByDateRange(startDate, endDate, member);
             return pendingDeals.stream()
                     .map(MemberMapper::toMyBuyingPendingDealHistoryResponse)
                     .collect(Collectors.toList());
         }
 
-        return filterMyBuyingFinishedByDateRange(startDate, endDate, member).stream()
+        return filterMyFinishedByDateRange(startDate, endDate, member).stream()
                 .map(MemberMapper::toMyBuyingFinishedDealHistoryResponse)
                 .collect(Collectors.toList());
     }
@@ -151,49 +151,48 @@ public class MemberService implements UserDetailsService {
                 .orElseThrow(() -> new RuntimeException());
 
         if (status.equals("bidding")) {
-            List<Bid> sellingBids = filterMySellingBiddingByDateRange(startDate, endDate, member);
+            List<Bid> sellingBids = filterMyBiddingByDateRange(startDate, endDate, member, BidType.SELL_BID.getBidType());
             return sellingBids.stream()
                     .map(MemberMapper::toMySellingBidHistoryResponse)
                     .collect(Collectors.toList());
         } else if (status.equals("pending")) {
-            List<Deal> pendingDeals = filterMySellingPendingByDateRange(startDate, endDate, member);
+            List<Deal> pendingDeals = filterMyPendingByDateRange(startDate, endDate, member);
             return pendingDeals.stream()
                     .map(MemberMapper::toMySellingPendingDealHistoryResponse)
                     .collect(Collectors.toList());
         }
-        return filterMySellingFinishedByDateRange(startDate, endDate, member).stream()
+        return filterMyFinishedByDateRange(startDate, endDate, member).stream()
                 .map(MemberMapper::toMySellingFinishedDealHistoryResponse)
                 .collect(Collectors.toList());
     }
 
-    private List<Bid> filterMyBuyingBiddingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Bid> myBuyingBiddingHistory = bidRepository.findByMemberNumber(member.getMemberNumber());
+    private List<Bid> filterMyBiddingByDateRange(LocalDate startDate, LocalDate endDate, Member member, String bidType) {
+        List<Bid> myBiddingHistory = bidRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null & endDate == null) {
-            return myBuyingBiddingHistory.stream()
-                    .filter(bid -> bid.getBidType().getBidType().equals(BidType.BUY_BID.getBidType()))
+            return myBiddingHistory.stream()
+                    .filter(bid -> bid.getBidType().getBidType().equals(bidType))
                     .filter(bid -> bid.getBidStatus().getBidStatus().equals(BidStatus.WAITING_MATCHING.getBidStatus()))
                     .toList();
         }
 
-        return myBuyingBiddingHistory.stream()
-                .filter(bid -> bid.getBidType().getBidType().equals(BidType.BUY_BID.getBidType()))
+        return myBiddingHistory.stream()
+                .filter(bid -> bid.getBidType().getBidType().equals(bidType))
                 .filter(bid -> bid.getBidStatus().getBidStatus().equals(BidStatus.WAITING_MATCHING.getBidStatus()))
                 .filter(bid -> bid.getCreatedAt().toLocalDate().isAfter(startDate) &&
                         bid.getCreatedAt().toLocalDate().isBefore(endDate))
                 .toList();
     }
 
-
-    private List<Deal> filterMyBuyingPendingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Deal> myBuyingPendingHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
+    private List<Deal> filterMyPendingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
+        List<Deal> myPendingHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null && endDate == null) {
-            return myBuyingPendingHistory.stream()
-                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_TRANSFER.getDealStatus()))
-                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_TRANSFER.getDealStatus()))
+            return myPendingHistory.stream()
+                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_DEPOSIT.getDealStatus()))
+                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_DEPOSIT.getDealStatus()))
                     .toList();
         }
 
-        return myBuyingPendingHistory.stream()
+        return myPendingHistory.stream()
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_TRANSFER.getDealStatus()))
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_TRANSFER.getDealStatus()))
                 .filter(deal -> deal.getCreatedAt().toLocalDate().isAfter(startDate) &&
@@ -201,67 +200,16 @@ public class MemberService implements UserDetailsService {
                 .toList();
     }
 
-    private List<Deal> filterMyBuyingFinishedByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Deal> myBuyingFinishedHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
+    private List<Deal> filterMyFinishedByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
+        List<Deal> myFinishedHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
         if (startDate == null && endDate == null) {
-            return myBuyingFinishedHistory.stream()
+            return myFinishedHistory.stream()
                     .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.SUCCESS_DEAL.getDealStatus()))
                     .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.FAIL_DEAL.getDealStatus()))
                     .toList();
         }
 
-        return myBuyingFinishedHistory.stream()
-                .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.SUCCESS_DEAL.getDealStatus()))
-                .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.FAIL_DEAL.getDealStatus()))
-                .filter(deal -> deal.getTradedAt().toLocalDate().isAfter(startDate) &&
-                        deal.getTradedAt().toLocalDate().isBefore(endDate))
-                .toList();
-    }
-
-    private List<Bid> filterMySellingBiddingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Bid> mySellingBiddingHistory = bidRepository.findByMemberNumber(member.getMemberNumber());
-        if (startDate == null & endDate == null) {
-            return mySellingBiddingHistory.stream()
-                    .filter(bid -> bid.getBidType().getBidType().equals(BidType.SELL_BID.getBidType()))
-                    .filter(bid -> bid.getBidStatus().getBidStatus().equals(BidStatus.WAITING_MATCHING.getBidStatus()))
-                    .toList();
-        }
-
-        return mySellingBiddingHistory.stream()
-                .filter(bid -> bid.getBidType().getBidType().equals(BidType.SELL_BID.getBidType()))
-                .filter(bid -> bid.getBidStatus().getBidStatus().equals(BidStatus.WAITING_MATCHING.getBidStatus()))
-                .filter(bid -> bid.getCreatedAt().toLocalDate().isAfter(startDate) &&
-                        bid.getCreatedAt().toLocalDate().isBefore(endDate))
-                .toList();
-    }
-
-    private List<Deal> filterMySellingPendingByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Deal> mySellingPendingHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
-        if (startDate == null && endDate == null) {
-            return mySellingPendingHistory.stream()
-                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_DEPOSIT.getDealStatus()))
-                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_DEPOSIT.getDealStatus()))
-                    .toList();
-        }
-
-        return mySellingPendingHistory.stream()
-                .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.WAITING_DEPOSIT.getDealStatus()))
-                .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.COMPLETE_DEPOSIT.getDealStatus()))
-                .filter(deal -> deal.getCreatedAt().toLocalDate().isAfter(startDate) &&
-                        deal.getCreatedAt().toLocalDate().isBefore(endDate))
-                .toList();
-    }
-
-    private List<Deal> filterMySellingFinishedByDateRange(LocalDate startDate, LocalDate endDate, Member member) {
-        List<Deal> mySellingFinishedHistory = dealRepository.findByMemberNumber(member.getMemberNumber());
-        if (startDate == null && endDate == null) {
-            return mySellingFinishedHistory.stream()
-                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.SUCCESS_DEAL.getDealStatus()))
-                    .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.FAIL_DEAL.getDealStatus()))
-                    .toList();
-        }
-
-        return mySellingFinishedHistory.stream()
+        return myFinishedHistory.stream()
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.SUCCESS_DEAL.getDealStatus()))
                 .filter(deal -> deal.getDealStatus().getDealStatus().equals(DealStatus.FAIL_DEAL.getDealStatus()))
                 .filter(deal -> deal.getTradedAt().toLocalDate().isAfter(startDate) &&


### PR DESCRIPTION
#36 중 상품 구매/판매 프로세스 구현에 대한 pr입니다.

구현 프로세스 (구매자 입장)
1. 구매자는 즉시 구매 가격으로 즉시 구매를 할 수 있고, 즉시 구매 가격보다 낮은 가격으로 구매 입찰을 할 수있다.
2. 구매 입찰시 해당 가격의 판매 상품이 없다면 bid테이블에 waiting_matching상태로 저장된다.
3. 구매자가 입찰 등록한 가격으로 판매자가 상품을 판매 입찰 하면 waiting_matching -> complete_matching상태로 변경된다.
4. 이후 deal 테이블에 입금 전 거래 정보가 저장된다. (waiting_deposit 상태)

구현 프로세스 (판매자 입장)
1. 판매자는 즉시 판매 가격으로 즉시 판매를 할 수 있고, 즉시 판매 가격보다 낮은 가격으로 판매 입찰을 할 수있다.
2. 판매 입찰시 해당 가격의 구매 상품이 없다면 bid테이블에 waiting_matching상태로 저장된다.
3. 판매자가 입찰 등록한 가격으로 구매자가 상품을 구매 입찰 하면 waiting_matching -> complete_matching상태로 변경된다.
4. 이후 deal 테이블에 입금 전 거래 정보가 저장된다. (waiting_deposit 상태)

TODO 
카카오 페이 API를 연동하여 deal 테이블의 입금 전 정보를 가지고 결제 후 결제가 마무리되는 프로세스 구현하기