### PR TITLE
[feat/kakao-pay] 배포 프로토콜 수정 http -> https

### DIFF
--- a/src/main/java/com/sideproject/shoescream/bid/repository/DealRepository.java
+++ b/src/main/java/com/sideproject/shoescream/bid/repository/DealRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public interface DealRepository extends JpaRepository<Deal, Long> {
 
-    List<Deal> findByProductId(Long productNumber);
+    List<Deal> findByProduct_ProductNumber(Long productNumber);
 
     @Query("select d from Deal d where d.buyerNumber=:memberNumber or d.sellerNumber=:memberNumber")
     List<Deal> findByMemberNumber(@Param("memberNumber") Long memberNumber);

--- a/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
+++ b/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
@@ -40,12 +40,12 @@ public class BidService {
     private final MemberRepository memberRepository;
 
     public SellingProductInfoResponse getSellingProductInfo(Long productNumber, String size) {
-        ProductOption product = productOptionRepository.findByProductIdAndSize(productNumber, size);
+        ProductOption product = productOptionRepository.findByProduct_ProductNumberAndSize(productNumber, size);
         return BidMapper.toSellingProductInfoResponse(product);
     }
 
     public BuyingProductInfoResponse getBuyingProductInfo(Long productNumber, String size, Authentication authentication) {
-        ProductOption product = productOptionRepository.findByProductIdAndSize(productNumber, size);
+        ProductOption product = productOptionRepository.findByProduct_ProductNumberAndSize(productNumber, size);
         return BidMapper.toBuyingProductInfoResponse(product);
     }
 
@@ -60,7 +60,7 @@ public class BidService {
     public SellingBidResponse sellingBid(SellingBidRequest sellingBidRequest, Authentication authentication) {
         Member member = memberRepository.findByMemberId(authentication.getName())
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-        ProductOption productOption = productOptionRepository.findByProductIdAndSize(sellingBidRequest.productNumber(), sellingBidRequest.size());
+        ProductOption productOption = productOptionRepository.findByProduct_ProductNumberAndSize(sellingBidRequest.productNumber(), sellingBidRequest.size());
         Optional<Bid> buyBid = bidRepository.findTargetBidOne(productOption.getProduct().getProductNumber(), sellingBidRequest.price(), BidType.BUY_BID);
 
         if (buyBid.isEmpty()) {
@@ -78,7 +78,7 @@ public class BidService {
     public BuyingBidResponse buyingBid(BuyingBidRequest buyingBidRequest, Authentication authentication) {
         Member member = memberRepository.findByMemberId(authentication.getName())
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
-        ProductOption productOption = productOptionRepository.findByProductIdAndSize(buyingBidRequest.productNumber(), buyingBidRequest.size());
+        ProductOption productOption = productOptionRepository.findByProduct_ProductNumberAndSize(buyingBidRequest.productNumber(), buyingBidRequest.size());
         Optional<Bid> sellBid = bidRepository.findTargetBidOne(productOption.getProduct().getProductNumber(), buyingBidRequest.price(), BidType.SELL_BID);
 
         if (sellBid.isEmpty()) {

--- a/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
+++ b/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
@@ -64,6 +64,7 @@ public class BidService {
         Optional<Bid> buyBid = bidRepository.findTargetBidOne(productOption.getProduct().getProductNumber(), sellingBidRequest.price(), BidType.BUY_BID);
 
         if (buyBid.isEmpty()) {
+            updateBuyNowPrice(productOption.getLowestPrice(), sellingBidRequest.price(), productOption);
             return BidMapper.toSellingBidResponse(bidRepository.save(
                     BidMapper.toSellingBid(
                             sellingBidRequest, member, productOption, BidType.SELL_BID)));
@@ -82,6 +83,7 @@ public class BidService {
         Optional<Bid> sellBid = bidRepository.findTargetBidOne(productOption.getProduct().getProductNumber(), buyingBidRequest.price(), BidType.SELL_BID);
 
         if (sellBid.isEmpty()) {
+            updateSellNowPrice(productOption.getHighestPrice(), buyingBidRequest.price(), productOption);
             return BidMapper.toBuyingBidResponse(bidRepository.save(
                     BidMapper.toBuyingBid(
                             buyingBidRequest, member, productOption, BidType.BUY_BID)));
@@ -90,5 +92,17 @@ public class BidService {
         sellBid.get().setBidStatus(BidStatus.COMPLETE_MATCHING);
         dealRepository.save(DealMapper.buyingBidToDeal(buyingBidRequest, productOption, sellBid.get(), member.getMemberNumber(), DealStatus.WAITING_DEPOSIT));
         return BidMapper.toBuyingBidResponse(BidMapper.toBuyingBid(buyingBidRequest, member, productOption, BidType.BUY_NOW));
+    }
+
+    private void updateSellNowPrice(int currentSellNowPrice, int buyBidPrice, ProductOption productOption) {
+        if (currentSellNowPrice < buyBidPrice) {
+            productOption.setHighestPrice(buyBidPrice);
+        }
+    }
+
+    private void updateBuyNowPrice(int currentBuyNowPrice, int sellBidPrice, ProductOption productOption) {
+        if (currentBuyNowPrice > sellBidPrice) {
+            productOption.setLowestPrice(sellBidPrice);
+        }
     }
 }

--- a/src/main/java/com/sideproject/shoescream/bid/service/DealService.java
+++ b/src/main/java/com/sideproject/shoescream/bid/service/DealService.java
@@ -20,7 +20,7 @@ public class DealService {
     private final ProductRepository productRepository;
 
     public QuoteResponse getQuote(String productNumber, String size, int period) {
-        List<Deal> deals = dealRepository.findByProductId(Long.valueOf(productNumber));
+        List<Deal> deals = dealRepository.findByProduct_ProductNumber(Long.valueOf(productNumber));
         return DealMapper.toQuoteResponse(deals, size, period);
     }
 

--- a/src/main/java/com/sideproject/shoescream/global/controller/StatusCheckController.java
+++ b/src/main/java/com/sideproject/shoescream/global/controller/StatusCheckController.java
@@ -1,0 +1,15 @@
+package com.sideproject.shoescream.global.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class StatusCheckController {
+
+    @GetMapping("/health-check")
+    public ResponseEntity<Void> checkHealthStatus() {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/sideproject/shoescream/product/dto/response/ProductRankingResponse.java
+++ b/src/main/java/com/sideproject/shoescream/product/dto/response/ProductRankingResponse.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record ProductRankingResponse(
-        Long id,
+        Long productNumber,
         String productName,
         String productSubName,
         String brandName,

--- a/src/main/java/com/sideproject/shoescream/product/dto/response/ProductResponse.java
+++ b/src/main/java/com/sideproject/shoescream/product/dto/response/ProductResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 
 @Builder
 public record ProductResponse(
-        Long id,
+        Long productNumber,
         String productCode,
         String productName,
         String productSubName,

--- a/src/main/java/com/sideproject/shoescream/product/repository/ProductOptionRepository.java
+++ b/src/main/java/com/sideproject/shoescream/product/repository/ProductOptionRepository.java
@@ -4,6 +4,6 @@ import com.sideproject.shoescream.product.entity.ProductOption;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductOptionRepository extends JpaRepository<ProductOption, Long> {
-    ProductOption findByProductIdAndSize(Long productNumber, String size);
-    ProductOption findByProductId(Long productNumber);
+    ProductOption findByProduct_ProductNumberAndSize(Long productNumber, String size);
+    ProductOption findByProduct_ProductNumber(Long productNumber);
 }

--- a/src/main/java/com/sideproject/shoescream/product/util/ProductMapper.java
+++ b/src/main/java/com/sideproject/shoescream/product/util/ProductMapper.java
@@ -13,7 +13,7 @@ public class ProductMapper {
 
     public static ProductResponse toProductResponse(Product product) {
         return ProductResponse.builder()
-                .id(product.getProductNumber())
+                .productNumber(product.getProductNumber())
                 .productCode(product.getProductCode())
                 .productName(product.getProductName())
                 .productSubName(product.getProductSubName())
@@ -53,7 +53,7 @@ public class ProductMapper {
 
     public static ProductRankingResponse toProductRankingResponse(Product product) {
         return ProductRankingResponse.builder()
-                .id(product.getProductNumber())
+                .productNumber(product.getProductNumber())
                 .productCode(product.getProductCode())
                 .productName(product.getProductName())
                 .productSubName(product.getProductSubName())


### PR DESCRIPTION
#39 이슈 중 health - check api 추가에 대한 pr입니다.

THIS
https 프로토콜로 수정 + 추후 무중단 배포를 위해 Nginx 웹 서버를 연동하였습니다.

Nginx 서버에서 제공하는 Reverse Proxy 기능 적용(외부에서 내부 서버접근할 때의 요청을 Proxy로 관리)
-> 외부 http://~~~:port 요청 -> https://도메인 ~~ 로 redirection

ERROR
1. 연동 후 웹 서버 테스트 중 간헐적으로 502 BadGateWay 오류가 발생
2. 80, 8080, 443 port에 대해 AWS 로드밸런서 대상그룹의 상태가 Unhealthy임을 확인
3. 30초마다 루트경로(/)로 http 상태 코드 검사를 하는데 404에러 로그 확인
4. 명시적으로 /health-check 경로로 들어오는 요청에대해 200코드를 반환하는 로직 추가하여 해결(루트 경로에 대한 상태코드가 왜 404인지는 잘 모르겠음)