### PR TITLE
[feat/bid] 상품 구매 + 결제 구현

### DIFF
--- a/src/main/java/com/sideproject/shoescream/bid/controller/BidController.java
+++ b/src/main/java/com/sideproject/shoescream/bid/controller/BidController.java
@@ -22,7 +22,7 @@ public class BidController {
 
     @PostMapping("/buy")
     public Response<BuyingBidResponse> buyingBid(@RequestBody BuyingBidRequest buyingBidRequest, Authentication authentication) {
-        return Response.success(bidService.buyingBid(buyingBidRequest, authentication));
+        return Response.success(bidService.buyingBid(buyingBidRequest, authentication.getName()));
     }
 
     @GetMapping("/sell/{productNumber}")
@@ -32,12 +32,17 @@ public class BidController {
 
     @PostMapping("/sell")
     public Response<SellingBidResponse> sellingBid(@RequestBody SellingBidRequest sellingBidRequest, Authentication authentication) {
-        return Response.success(bidService.sellingBid(sellingBidRequest, authentication));
+        return Response.success(bidService.sellingBid(sellingBidRequest, authentication.getName()));
     }
-
 
     @GetMapping("/bid-history")
     public Response<BidHistoryResponse> getBidHistory(@RequestParam String productNumber, @RequestParam String size) {
         return Response.success(bidService.getBidHistory(productNumber, size));
+    }
+
+
+    @PostMapping("/sell-now")
+    public Response<SellingBidResponse> sellingNow(@RequestBody SellingBidRequest sellingBidRequest, Authentication authentication) {
+        return Response.success(bidService.sellingNow(sellingBidRequest, authentication.getName()));
     }
 }

--- a/src/main/java/com/sideproject/shoescream/bid/dto/response/BuyingProductInfoResponse.java
+++ b/src/main/java/com/sideproject/shoescream/bid/dto/response/BuyingProductInfoResponse.java
@@ -10,6 +10,8 @@ public record BuyingProductInfoResponse(
 
         String productSubName,
 
+        String productImage,
+
         int lowestPrice,
 
         int highestPrice

--- a/src/main/java/com/sideproject/shoescream/bid/dto/response/SellingProductInfoResponse.java
+++ b/src/main/java/com/sideproject/shoescream/bid/dto/response/SellingProductInfoResponse.java
@@ -10,6 +10,8 @@ public record SellingProductInfoResponse(
 
         String productSubName,
 
+        String productImage,
+
         int lowestPrice,
 
         int highestPrice

--- a/src/main/java/com/sideproject/shoescream/bid/entity/Bid.java
+++ b/src/main/java/com/sideproject/shoescream/bid/entity/Bid.java
@@ -3,12 +3,14 @@ package com.sideproject.shoescream.bid.entity;
 import com.sideproject.shoescream.bid.constant.BidStatus;
 import com.sideproject.shoescream.bid.constant.BidType;
 import com.sideproject.shoescream.member.entity.Member;
+import com.sideproject.shoescream.notification.dto.request.NotificationRequest;
 import com.sideproject.shoescream.product.entity.Product;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.time.LocalDateTime;
 
@@ -52,5 +54,10 @@ public class Bid {
 
     protected Bid() {
 
+    }
+
+    public void publishEvent(ApplicationEventPublisher eventPublisher, NotificationRequest notificationRequest) {
+        System.out.println("하이");
+        eventPublisher.publishEvent(notificationRequest);
     }
 }

--- a/src/main/java/com/sideproject/shoescream/bid/repository/BidRepository.java
+++ b/src/main/java/com/sideproject/shoescream/bid/repository/BidRepository.java
@@ -14,8 +14,9 @@ public interface BidRepository extends JpaRepository<Bid, Long> {
     @Query("select b from Bid b where b.member.memberNumber = :memberNumber")
     List<Bid> findByMemberNumber(@Param("memberNumber") Long memberNumber);
 
-    @Query("select b from Bid b where b.product.productNumber =:productNumber and b.bidPrice =:bidPrice and b.bidType =:bidType order by b.createdAt")
-    Optional<Bid> findTargetBidOne(@Param("productNumber") Long productNumber,
+    @Query("select b from Bid b where b.product.productNumber =:productNumber and b.bidPrice =:bidPrice and b.size =:size and b.bidType =:bidType order by b.createdAt")
+    List<Bid> findTargetBidOne(@Param("productNumber") Long productNumber,
                                 @Param("bidPrice") int bidPrice,
+                                @Param("size") String size,
                                 @Param("bidType") BidType bidType);
 }

--- a/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
+++ b/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
@@ -1,8 +1,6 @@
 package com.sideproject.shoescream.bid.service;
 
-import com.sideproject.shoescream.bid.constant.BidStatus;
 import com.sideproject.shoescream.bid.constant.BidType;
-import com.sideproject.shoescream.bid.constant.DealStatus;
 import com.sideproject.shoescream.bid.dto.request.BuyingBidRequest;
 import com.sideproject.shoescream.bid.dto.request.SellingBidRequest;
 import com.sideproject.shoescream.bid.dto.response.*;
@@ -10,23 +8,22 @@ import com.sideproject.shoescream.bid.entity.Bid;
 import com.sideproject.shoescream.bid.repository.BidRepository;
 import com.sideproject.shoescream.bid.repository.DealRepository;
 import com.sideproject.shoescream.bid.util.BidMapper;
-import com.sideproject.shoescream.bid.util.DealMapper;
 import com.sideproject.shoescream.global.exception.ErrorCode;
 import com.sideproject.shoescream.member.entity.Member;
 import com.sideproject.shoescream.member.exception.MemberNotFoundException;
 import com.sideproject.shoescream.member.repository.MemberRepository;
+import com.sideproject.shoescream.notification.constant.NotificationType;
+import com.sideproject.shoescream.notification.dto.request.NotificationRequest;
 import com.sideproject.shoescream.product.entity.Product;
 import com.sideproject.shoescream.product.entity.ProductOption;
 import com.sideproject.shoescream.product.repository.ProductImageRepository;
 import com.sideproject.shoescream.product.repository.ProductOptionRepository;
 import com.sideproject.shoescream.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +35,7 @@ public class BidService {
     private final ProductImageRepository productImageRepository;
     private final DealRepository dealRepository;
     private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public SellingProductInfoResponse getSellingProductInfo(Long productNumber, String size) {
         ProductOption product = productOptionRepository.findByProduct_ProductNumberAndSize(productNumber, size);
@@ -57,8 +55,8 @@ public class BidService {
     }
 
     @Transactional
-    public SellingBidResponse sellingBid(SellingBidRequest sellingBidRequest, Authentication authentication) {
-        Member member = memberRepository.findByMemberId(authentication.getName())
+    public SellingBidResponse sellingBid(SellingBidRequest sellingBidRequest, String memberId) {
+        Member member = memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
         ProductOption productOption = productOptionRepository.findByProduct_ProductNumberAndSize(sellingBidRequest.productNumber(), sellingBidRequest.size());
 
@@ -69,8 +67,22 @@ public class BidService {
     }
 
     @Transactional
-    public BuyingBidResponse buyingBid(BuyingBidRequest buyingBidRequest, Authentication authentication) {
-        Member member = memberRepository.findByMemberId(authentication.getName())
+    public SellingBidResponse sellingNow(SellingBidRequest sellingBidRequest, String memberId) {
+        Member seller = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        Bid buyBidInfo = bidRepository.findTargetBidOne(
+                sellingBidRequest.productNumber(),
+                sellingBidRequest.price(),
+                sellingBidRequest.size(),
+                BidType.BUY_BID).get(0);
+
+        notifySellInfo(buyBidInfo, createNotificationRequest(buyBidInfo));
+        return BidMapper.toSellingBidResponse(buyBidInfo);
+    }
+
+    @Transactional
+    public BuyingBidResponse buyingBid(BuyingBidRequest buyingBidRequest, String memberId) {
+        Member member = memberRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
         ProductOption productOption = productOptionRepository.findByProduct_ProductNumberAndSize(buyingBidRequest.productNumber(), buyingBidRequest.size());
 
@@ -90,5 +102,18 @@ public class BidService {
         if (currentBuyNowPrice > sellBidPrice) {
             productOption.setLowestPrice(sellBidPrice);
         }
+    }
+
+    private void notifySellInfo(Bid bid, NotificationRequest notificationRequest) {
+        bid.publishEvent(eventPublisher, notificationRequest);
+    }
+
+    private NotificationRequest createNotificationRequest(Bid buyBidInfo) {
+        return NotificationRequest.builder()
+                .receiver(buyBidInfo.getMember())
+                .notificationType(NotificationType.PAYMENT)
+                .content("결제 알림")
+                .relatedUrl("test/url")
+                .build();
     }
 }

--- a/src/main/java/com/sideproject/shoescream/bid/util/BidMapper.java
+++ b/src/main/java/com/sideproject/shoescream/bid/util/BidMapper.java
@@ -21,6 +21,7 @@ public class BidMapper {
                 .productCode(productOption.getProduct().getProductCode())
                 .productName(productOption.getProduct().getProductName())
                 .productSubName(productOption.getProduct().getProductSubName())
+                .productImage(productOption.getProduct().getProductImages().get(0).getProductImage())
                 .lowestPrice(productOption.getLowestPrice())
                 .highestPrice(productOption.getHighestPrice())
                 .build();
@@ -54,6 +55,7 @@ public class BidMapper {
                 .productCode(productOption.getProduct().getProductCode())
                 .productName(productOption.getProduct().getProductName())
                 .productSubName(productOption.getProduct().getProductSubName())
+                .productImage(productOption.getProduct().getProductImages().get(0).getProductImage())
                 .lowestPrice(productOption.getLowestPrice())
                 .highestPrice(productOption.getHighestPrice())
                 .build();

--- a/src/main/java/com/sideproject/shoescream/member/entity/Member.java
+++ b/src/main/java/com/sideproject/shoescream/member/entity/Member.java
@@ -1,6 +1,7 @@
 package com.sideproject.shoescream.member.entity;
 
 import com.sideproject.shoescream.bid.entity.Bid;
+import com.sideproject.shoescream.notification.entity.Notification;
 import com.sideproject.shoescream.review.entity.Review;
 import com.sideproject.shoescream.review.entity.ReviewComment;
 import jakarta.persistence.*;
@@ -50,6 +51,9 @@ public class Member implements UserDetails {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<ReviewComment> reviewComments;
+
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL)
+    private List<Notification> notifications;
 
     protected Member() {
 

--- a/src/main/java/com/sideproject/shoescream/notification/component/NotificationListener.java
+++ b/src/main/java/com/sideproject/shoescream/notification/component/NotificationListener.java
@@ -1,0 +1,22 @@
+package com.sideproject.shoescream.notification.component;
+
+import com.sideproject.shoescream.notification.dto.request.NotificationRequest;
+import com.sideproject.shoescream.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationListener {
+
+    private final NotificationService notificationService;
+
+    @TransactionalEventListener
+    @Async
+    public void handleNotification(NotificationRequest notificationRequest) {
+        notificationService.send(notificationRequest.receiver(), notificationRequest.content(),
+                notificationRequest.relatedUrl(), notificationRequest.notificationType());
+    }
+}

--- a/src/main/java/com/sideproject/shoescream/notification/constant/NotificationType.java
+++ b/src/main/java/com/sideproject/shoescream/notification/constant/NotificationType.java
@@ -1,0 +1,11 @@
+package com.sideproject.shoescream.notification.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationType {
+    PAYMENT("payment");
+
+    NotificationType(String type) {
+    }
+}

--- a/src/main/java/com/sideproject/shoescream/notification/controller/NotificationController.java
+++ b/src/main/java/com/sideproject/shoescream/notification/controller/NotificationController.java
@@ -1,0 +1,23 @@
+package com.sideproject.shoescream.notification.controller;
+
+import com.sideproject.shoescream.global.dto.response.Response;
+import com.sideproject.shoescream.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/subscribe", produces = "text/event-stream")
+    public SseEmitter subscribe(@RequestHeader(value = "Last-Event-Id", required = false, defaultValue = "") String lastEventId,
+                                          Authentication authentication) {
+        return notificationService.subscribe(authentication.getName(), lastEventId);
+    }
+}

--- a/src/main/java/com/sideproject/shoescream/notification/dto/request/NotificationRequest.java
+++ b/src/main/java/com/sideproject/shoescream/notification/dto/request/NotificationRequest.java
@@ -1,0 +1,13 @@
+package com.sideproject.shoescream.notification.dto.request;
+
+import com.sideproject.shoescream.member.entity.Member;
+import com.sideproject.shoescream.notification.constant.NotificationType;
+import lombok.Builder;
+
+@Builder
+public record NotificationRequest(
+        Member receiver,
+        NotificationType notificationType,
+        String content,
+        String relatedUrl) {
+}

--- a/src/main/java/com/sideproject/shoescream/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sideproject/shoescream/notification/dto/response/NotificationResponse.java
@@ -1,0 +1,24 @@
+package com.sideproject.shoescream.notification.dto.response;
+
+import com.sideproject.shoescream.notification.entity.Notification;
+import lombok.Builder;
+
+@Builder
+public record NotificationResponse(
+        Long id,
+        String receiver,
+        String content,
+        String relatedUrl,
+        String type
+) {
+
+    public static NotificationResponse createNotificationResponse(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getNotificationNumber())
+                .receiver(notification.getReceiver().getMemberId())
+                .content(notification.getContent())
+                .relatedUrl("/test/url")
+                .type(notification.getNotificationType().toString())
+                .build();
+    }
+}

--- a/src/main/java/com/sideproject/shoescream/notification/entity/Notification.java
+++ b/src/main/java/com/sideproject/shoescream/notification/entity/Notification.java
@@ -1,0 +1,39 @@
+package com.sideproject.shoescream.notification.entity;
+
+import com.sideproject.shoescream.member.entity.Member;
+import com.sideproject.shoescream.notification.constant.NotificationType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+public class Notification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_number")
+    private Long notificationNumber;
+
+    @Column(name = "notification_content")
+    private String content;
+
+    @Column(name = "related_url")
+    private String relatedUrl;
+
+    @Enumerated(EnumType.STRING)
+    private NotificationType notificationType;
+
+    @ManyToOne
+    @JoinColumn(name = "receiver_number")
+    private Member receiver;
+
+    protected Notification() {
+
+    }
+}

--- a/src/main/java/com/sideproject/shoescream/notification/repository/EmitterRepository.java
+++ b/src/main/java/com/sideproject/shoescream/notification/repository/EmitterRepository.java
@@ -1,0 +1,16 @@
+package com.sideproject.shoescream.notification.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface EmitterRepository {
+
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+    void saveEventCache(String emitterId, Object event);
+    Map<String, SseEmitter> findAllEmitterStartWithByMemberNumber(String memberNumber);
+    Map<String, Object> findAllEventCacheStartWithByMemberNumber(String memberNumber);
+    void deleteById(String id);
+    void deleteAllEmitterStartWithMemberId(String memberId);
+    void deleteAllEventCacheStartWithMemberId(String memberId);
+}

--- a/src/main/java/com/sideproject/shoescream/notification/repository/EmitterRepositoryImpl.java
+++ b/src/main/java/com/sideproject/shoescream/notification/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.sideproject.shoescream.notification.repository;
+
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Repository
+@NoArgsConstructor
+public class EmitterRepositoryImpl implements EmitterRepository {
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId, sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String eventCacheId, Object event) {
+        eventCache.put(eventCacheId, event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithByMemberNumber(String memberNumber) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberNumber))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithByMemberNumber(String memberId) {
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String id) {
+        emitters.remove(id);
+    }
+
+    @Override
+    public void deleteAllEmitterStartWithMemberId(String memberId) {
+        emitters.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(memberId)) {
+                        emitters.remove(key);
+                    }
+                }
+        );
+    }
+
+    @Override
+    public void deleteAllEventCacheStartWithMemberId(String memberId) {
+        eventCache.forEach(
+                (key, emitter) -> {
+                    if (key.startsWith(memberId)) {
+                        eventCache.remove(key);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/com/sideproject/shoescream/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sideproject/shoescream/notification/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.sideproject.shoescream.notification.repository;
+
+import com.sideproject.shoescream.notification.entity.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/sideproject/shoescream/notification/service/NotificationService.java
+++ b/src/main/java/com/sideproject/shoescream/notification/service/NotificationService.java
@@ -1,0 +1,93 @@
+package com.sideproject.shoescream.notification.service;
+
+import com.sideproject.shoescream.member.entity.Member;
+import com.sideproject.shoescream.member.repository.MemberRepository;
+import com.sideproject.shoescream.notification.dto.response.NotificationResponse;
+import com.sideproject.shoescream.notification.constant.NotificationType;
+import com.sideproject.shoescream.notification.entity.Notification;
+import com.sideproject.shoescream.notification.repository.EmitterRepository;
+import com.sideproject.shoescream.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+
+    private static final Long SSE_TIME_OUT = 1800000L;
+
+    public SseEmitter subscribe(String memberId, String lastEventId) {
+        Member receiver = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new RuntimeException());
+        String emitterId = makeTimeIncludeId(receiver.getMemberNumber());
+        SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(SSE_TIME_OUT));
+        emitter.onCompletion(() -> emitterRepository.deleteById(emitterId));
+        emitter.onTimeout(() -> emitterRepository.deleteById(emitterId));
+
+        String eventId = makeTimeIncludeId(receiver.getMemberNumber());
+        sendNotification(emitter, eventId, emitterId, "EventStream Created. [userId=" + receiver.getMemberNumber() + "]");
+
+        // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
+        if (hasLostData(lastEventId)) {
+            sendLostData(lastEventId, receiver.getMemberNumber(), emitterId, emitter);
+        }
+
+        return emitter;
+    }
+
+    private String makeTimeIncludeId(Long memberNumber) {
+        return memberNumber + "_" + System.currentTimeMillis();
+    }
+
+    private void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .id(eventId)
+                    .data(data));
+        } catch (IOException e) {
+            emitterRepository.deleteById(emitterId);
+        }
+    }
+
+    private boolean hasLostData(String lastEventId) {
+        return !lastEventId.isEmpty();
+    }
+
+    private void sendLostData(String lastEventId, Long memberNumber, String emitterId, SseEmitter emitter) {
+        Map<String, Object> eventCaches = emitterRepository.findAllEventCacheStartWithByMemberNumber(String.valueOf(memberNumber));
+        eventCaches.entrySet().stream()
+                .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                .forEach(entry -> sendNotification(emitter, entry.getKey(), emitterId, entry.getValue()));
+    }
+
+    public void send(Member receiver, String content, String relatedUrl, NotificationType notificationType) {
+        Notification notification = notificationRepository.save(createNotification(receiver, content, relatedUrl, notificationType));
+
+        String receiverNumber = String.valueOf(receiver.getMemberNumber());
+        String eventId = receiverNumber + "_" + System.currentTimeMillis();
+        Map<String, SseEmitter> emitters = emitterRepository.findAllEmitterStartWithByMemberNumber(receiverNumber);
+        emitters.forEach(
+                (key, emitter) -> {
+                    emitterRepository.saveEventCache(key, notification);
+                    sendNotification(emitter, eventId, key, NotificationResponse.createNotificationResponse(notification));
+                }
+        );
+    }
+
+    private Notification createNotification(Member receiver, String content, String relatedUrl, NotificationType notificationType) {
+        return Notification.builder()
+                .receiver(receiver)
+                .content(content)
+                .relatedUrl(relatedUrl)
+                .notificationType(notificationType)
+                .build();
+    }
+}

--- a/src/test/java/com/sideproject/shoescream/notification/repository/EmitterRepositoryImplTest.java
+++ b/src/test/java/com/sideproject/shoescream/notification/repository/EmitterRepositoryImplTest.java
@@ -1,0 +1,168 @@
+package com.sideproject.shoescream.notification.repository;
+
+import com.sideproject.shoescream.member.entity.Member;
+import com.sideproject.shoescream.notification.constant.NotificationType;
+import com.sideproject.shoescream.notification.entity.Notification;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EmitterRepositoryImplTest {
+
+    private EmitterRepository emitterRepository = new EmitterRepositoryImpl();
+    private Long DEFAULT_TIMEOUT = 60L * 1000L * 60L;
+
+    @Test
+    @DisplayName("새로운 Emitter를 추가한다.")
+    void save() throws Exception {
+        // Given
+        Long memberNumber = 1L;
+        String emitterId = memberNumber + "_" + System.currentTimeMillis();
+        SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+
+        // When, Then
+        Assertions.assertDoesNotThrow(() -> emitterRepository.save(emitterId, sseEmitter));
+    }
+
+    @Test
+    @DisplayName("수신한 이벤트를 캐시에 저장한다.")
+    void saveEventCache() throws Exception {
+        // Given
+        Long memberNumber = 1L;
+        String eventCacheId = memberNumber + "_" + System.currentTimeMillis();
+        Notification notification = createNotification("거래가 성사 되었습니다.", "test/url");
+
+        // When, Then
+        Assertions.assertDoesNotThrow(() -> emitterRepository.saveEventCache(eventCacheId, notification));
+    }
+
+    @Test
+    @DisplayName("어떤 회원이 접속한 모든 Emitter를 찾는다.")
+    void findAllEmitterStartWithByMemberNumber() throws Exception {
+        // Given
+        Long memberNumber = 1L;
+        String emitterId1 = memberNumber + "_" + System.currentTimeMillis();
+        emitterRepository.save(emitterId1, new SseEmitter(DEFAULT_TIMEOUT));
+
+        Thread.sleep(100);
+        String emitterId2 = memberNumber + "_" + System.currentTimeMillis();
+        emitterRepository.save(emitterId2, new SseEmitter(DEFAULT_TIMEOUT));
+
+        Thread.sleep(100);
+        String emitterId3 = memberNumber + "_" + System.currentTimeMillis();
+        emitterRepository.save(emitterId3, new SseEmitter(DEFAULT_TIMEOUT));
+
+        // When
+        Map<String, SseEmitter> result = emitterRepository.findAllEmitterStartWithByMemberNumber(String.valueOf(memberNumber));
+
+        // Then
+        Assertions.assertEquals(3, result.size());
+    }
+
+    @Test
+    @DisplayName("어떤 회원에게 수신된 이벤트를 캐시에서 모두 찾는다.")
+    void findAllEventCacheStartWithByMemberNumber() throws Exception {
+        // Given
+        Long memberNumber = 1L;
+        String eventCacheId1 = memberNumber + "_" + System.currentTimeMillis();
+        Notification notification1 = createNotification("거래가 성사 되었습니다1", "test/url1");
+
+        emitterRepository.saveEventCache(eventCacheId1, notification1);
+
+        Thread.sleep(100);
+        String eventCacheId2 = memberNumber + "_" + System.currentTimeMillis();
+        Notification notification2 = createNotification("거래가 성사 되었습니다2", "test/url2");
+
+        emitterRepository.saveEventCache(eventCacheId2, notification2);
+
+        // When
+        Map<String, Object> resut = emitterRepository.findAllEventCacheStartWithByMemberNumber(String.valueOf(memberNumber));
+
+        // Then
+        Assertions.assertEquals(2, resut.size());
+    }
+
+    @Test
+    @DisplayName("Id를 통해 Emitter를 Repository에서 제거한다.")
+    void deleteById() throws Exception {
+        // Given
+        Long memberNumber = 1L;
+        String emitterId = memberNumber + "_" + System.currentTimeMillis();
+        SseEmitter sseEmitter = new SseEmitter(DEFAULT_TIMEOUT);
+
+        // When
+        emitterRepository.save(emitterId, sseEmitter);
+        emitterRepository.deleteById(emitterId);
+
+        // Then
+        Assertions.assertEquals(0, emitterRepository.findAllEmitterStartWithByMemberNumber(emitterId).size());
+    }
+
+    @Test
+    @DisplayName("저장된 모든 Emitter를 제거한다.")
+    void deleteAllEmitterStartWithId() throws Exception {
+        // Given
+        Long memberNumber = 1L;
+        String emitterId1 = memberNumber + "_" + System.currentTimeMillis();
+        emitterRepository.save(emitterId1, new SseEmitter(DEFAULT_TIMEOUT));
+
+        Thread.sleep(100);
+        String emitterId2 = memberNumber + "_" + System.currentTimeMillis();
+        emitterRepository.save(emitterId2, new SseEmitter(DEFAULT_TIMEOUT));
+
+        // When
+        emitterRepository.deleteAllEmitterStartWithMemberId(String.valueOf(memberNumber));
+
+        // Then
+        Assertions.assertEquals(0, emitterRepository.findAllEmitterStartWithByMemberNumber(String.valueOf(memberNumber)).size());
+    }
+
+    @Test
+    @DisplayName("캐시에 저장된 모든 Emitter를 제거한다.")
+    void deleteAllEventCacheStartWithId() throws Exception {
+        // Given
+        Long memberNumber = 1L;
+        String eventCacheId1 = memberNumber + "_" + System.currentTimeMillis();
+        Notification notification1 = createNotification("거래 성사1", "test/url1");
+
+        emitterRepository.saveEventCache(eventCacheId1, notification1);
+
+        Thread.sleep(100);
+        String eventCacheId2 = memberNumber + "_" + System.currentTimeMillis();
+        Notification notification2 = createNotification("거래 성사2", "test/url2");
+
+        emitterRepository.saveEventCache(eventCacheId2, notification2);
+
+        // When
+        emitterRepository.deleteAllEventCacheStartWithMemberId(String.valueOf(memberNumber));
+
+        // Then
+        Assertions.assertEquals(0, emitterRepository.findAllEventCacheStartWithByMemberNumber(String.valueOf(memberNumber)).size());
+    }
+
+    private Notification createNotification(String content, String relatedUrl) {
+        return Notification.builder()
+                .content(content)
+                .relatedUrl(relatedUrl)
+                .receiver(createMember(1L))
+                .notificationType(NotificationType.PAYMENT)
+                .build();
+    }
+
+    private Member createMember(Long memberNumber) {
+        return Member.builder()
+                .memberNumber(memberNumber)
+                .memberId("wnsdhqo")
+                .password("Gkrehd102!")
+                .email("wnsdhqo@naver.com")
+                .name("배준오")
+                .profileImage("/test/url")
+                .build();
+    }
+
+}

--- a/src/test/java/com/sideproject/shoescream/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/sideproject/shoescream/notification/service/NotificationServiceTest.java
@@ -1,0 +1,92 @@
+package com.sideproject.shoescream.notification.service;
+
+import com.sideproject.shoescream.member.entity.Member;
+import com.sideproject.shoescream.member.repository.MemberRepository;
+import com.sideproject.shoescream.notification.constant.NotificationType;
+import com.sideproject.shoescream.notification.entity.Notification;
+import com.sideproject.shoescream.notification.repository.EmitterRepository;
+import com.sideproject.shoescream.notification.repository.NotificationRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationServiceTest {
+
+    @InjectMocks
+    NotificationService notificationService;
+
+    @Mock
+    NotificationRepository notificationRepository;
+
+    @Mock
+    EmitterRepository emitterRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("알림 구독을 진행")
+    void subscribe() throws Exception {
+        // Given
+        Member member = createMember("wnsdhqo");
+        given(memberRepository.findByMemberId(member.getMemberId())).willReturn(Optional.of(member));
+
+        SseEmitter sseEmitter = new SseEmitter();
+        given(emitterRepository.save(anyString(), any(SseEmitter.class))).willReturn(sseEmitter);
+
+        // When
+        String lastEventId = "";
+        SseEmitter result = notificationService.subscribe(member.getMemberId(), lastEventId);
+
+        // Then
+        assertNotNull(result);
+    }
+
+    @Test
+    @DisplayName("알림 메세지를 전송한다.")
+    void send() throws Exception {
+        // Given
+        Member member = createMember("wnsdhqo");
+        SseEmitter sseEmitter = new SseEmitter();
+        String lastEventId = "";
+        given(memberRepository.findByMemberId(member.getMemberId())).willReturn(Optional.of(member));
+        given(emitterRepository.save(anyString(), any(SseEmitter.class))).willReturn(sseEmitter);
+        given(notificationRepository.save(any(Notification.class))).willReturn(createNotification(member, "결제 알림", "test/url", NotificationType.PAYMENT));
+
+        // When
+        notificationService.subscribe(member.getMemberId(), lastEventId);
+
+        // Then
+        Assertions.assertDoesNotThrow(() -> notificationService.send(member, "결제 알림", "test/url", NotificationType.PAYMENT));
+    }
+
+    private Member createMember(String memberId) {
+        return Member.builder()
+                .memberId(memberId)
+                .password("Gkrehd102!")
+                .email("wnsdhqo@naver.com")
+                .name("배준오")
+                .profileImage(null)
+                .build();
+    }
+
+    private Notification createNotification(Member receiver, String content, String relatedUrl, NotificationType notificationType) {
+        return Notification.builder()
+                .receiver(receiver)
+                .content(content)
+                .relatedUrl(relatedUrl)
+                .notificationType(notificationType)
+                .build();
+    }
+}


### PR DESCRIPTION
#39 에 대한 구현 사항을 포함하는 pr입니다.

THIS
* Sse를 사용하여 즉시 판매시 구매자에게 결제를 요청하는 실시간 알림을 보내는 기능을 추가했습니다.

유즈 케이스
1. 사용자1은 구매 입찰 등록을 하여 판매자와 매칭을 기다리는 상태
2. 사용자2는 사용자1이 등록한 상품을 즉시 판매하고자 하는 상황
3. 사용자2가 즉시 판매시 사용자 1에게 결제정보를 포함한 알림 전송

클라이언트 - 서버
1. 클라이언트는 사용자 1이 로그인 상태(Jwt 유효 시간)인 동안 Sse 알림을 받을 수 있도록 알림 구독을 한다. (서버와 연결 유지)
2. 서버는 사용자 2가 즉시 판매시 사용자1에게 알림을 보내는 메서드를 호출
3. 클라이언트 측에서 알림을 수신

알림 구독 상태인 동안 사용자 1의 상태
![image](https://github.com/shoescream/backend/assets/109403631/df10a70c-e21e-4194-9111-8c7c4cf6b1ad)
