### PR TITLE
[feat/bid] sse 알림 dto response 수정

### DIFF
--- a/src/main/java/com/sideproject/shoescream/bid/dto/response/BuyingBidResponse.java
+++ b/src/main/java/com/sideproject/shoescream/bid/dto/response/BuyingBidResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 @Builder
 public record BuyingBidResponse(
+        String productName,
         String size,
         int price,
         int quantity,

--- a/src/main/java/com/sideproject/shoescream/bid/entity/Bid.java
+++ b/src/main/java/com/sideproject/shoescream/bid/entity/Bid.java
@@ -57,7 +57,6 @@ public class Bid {
     }
 
     public void publishEvent(ApplicationEventPublisher eventPublisher, NotificationRequest notificationRequest) {
-        System.out.println("하이");
         eventPublisher.publishEvent(notificationRequest);
     }
 }

--- a/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
+++ b/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
@@ -109,10 +109,11 @@ public class BidService {
 
     private NotificationRequest createNotificationRequest(Bid buyBidInfo) {
         return NotificationRequest.builder()
+                .domainNumber(buyBidInfo.getBidNumber())
                 .receiver(buyBidInfo.getMember())
                 .notificationType(NotificationType.PAYMENT)
                 .content("결제 알림")
-                .relatedUrl("test/url")
+                .object(BidMapper.toBuyingBidResponse(buyBidInfo))
                 .build();
     }
 

--- a/src/main/java/com/sideproject/shoescream/bid/util/BidMapper.java
+++ b/src/main/java/com/sideproject/shoescream/bid/util/BidMapper.java
@@ -77,6 +77,7 @@ public class BidMapper {
 
     public static BuyingBidResponse toBuyingBidResponse(Bid bid) {
         return BuyingBidResponse.builder()
+                .productName(bid.getProduct().getProductName())
                 .size(bid.getSize())
                 .price(bid.getBidPrice())
                 .quantity(1)

--- a/src/main/java/com/sideproject/shoescream/member/controller/MemberController.java
+++ b/src/main/java/com/sideproject/shoescream/member/controller/MemberController.java
@@ -5,10 +5,7 @@ import com.sideproject.shoescream.member.dto.request.KaKaoSignInRequest;
 import com.sideproject.shoescream.member.dto.request.MemberFindMemberInfoRequest;
 import com.sideproject.shoescream.member.dto.request.MemberSignInRequest;
 import com.sideproject.shoescream.member.dto.request.MemberSignUpRequest;
-import com.sideproject.shoescream.member.dto.response.MemberResponse;
-import com.sideproject.shoescream.member.dto.response.MemberSignInResponse;
-import com.sideproject.shoescream.member.dto.response.MyBuyingHistoryResponse;
-import com.sideproject.shoescream.member.dto.response.MySellingHistoryResponse;
+import com.sideproject.shoescream.member.dto.response.*;
 import com.sideproject.shoescream.member.service.EmailService;
 import com.sideproject.shoescream.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -17,7 +14,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
@@ -79,5 +75,15 @@ public class MemberController {
             Authentication authentication) {
         return Response.success(memberService.getMySellingHistory(status, startDate, endDate, authentication));
 
+    }
+
+    @GetMapping("/my/notification")
+    public Response<List<MyNotificationResponse>> getMyNotifications(Authentication authentication) {
+        return Response.success(memberService.getMyNotifications(authentication.getName()));
+    }
+
+    @GetMapping("/my/notification/{notificationNumber}")
+    public Response<MyNotificationResponse> getMyNotification(@PathVariable String notificationNumber, Authentication authentication) {
+        return Response.success(memberService.getMyNotification(notificationNumber, authentication.getName()));
     }
 }

--- a/src/main/java/com/sideproject/shoescream/member/dto/response/MyNotificationResponse.java
+++ b/src/main/java/com/sideproject/shoescream/member/dto/response/MyNotificationResponse.java
@@ -1,0 +1,18 @@
+package com.sideproject.shoescream.member.dto.response;
+
+import com.sideproject.shoescream.notification.constant.NotificationType;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record MyNotificationResponse(
+        long notificationNumber,
+        String notificationContent,
+        NotificationType notificationType,
+        String buyerId,
+        LocalDateTime createdAt,
+        boolean isRead,
+        Object object
+) {
+}

--- a/src/main/java/com/sideproject/shoescream/member/util/MemberMapper.java
+++ b/src/main/java/com/sideproject/shoescream/member/util/MemberMapper.java
@@ -5,11 +5,7 @@ import com.sideproject.shoescream.bid.entity.Deal;
 import com.sideproject.shoescream.member.dto.request.MemberSignUpRequest;
 import com.sideproject.shoescream.member.dto.response.*;
 import com.sideproject.shoescream.member.entity.Member;
-import com.sideproject.shoescream.product.entity.Product;
-import com.sideproject.shoescream.product.util.ProductMapper;
-
-import java.util.List;
-import java.util.stream.Collectors;
+import com.sideproject.shoescream.notification.entity.Notification;
 
 public class MemberMapper {
 
@@ -114,6 +110,27 @@ public class MemberMapper {
                 .size(myDeal.getSize())
                 .tradedAt(myDeal.getTradedAt())
                 .status(myDeal.getDealStatus().getDealStatus())
+                .build();
+    }
+
+    public static MyNotificationResponse toMyNotificationResponse(Notification notification) {
+        return MyNotificationResponse.builder()
+                .notificationNumber(notification.getNotificationNumber())
+                .notificationContent(notification.getNotificationContent())
+                .notificationType(notification.getNotificationType())
+                .buyerId(notification.getReceiver().getMemberId())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+
+    public static MyNotificationResponse toMyNotificationResponse(Notification notification, Object object){
+        return MyNotificationResponse.builder()
+                .notificationNumber(notification.getNotificationNumber())
+                .notificationContent(notification.getNotificationContent())
+                .notificationType(notification.getNotificationType())
+                .buyerId(notification.getReceiver().getMemberId())
+                .createdAt(notification.getCreatedAt())
+                .object(object)
                 .build();
     }
 }

--- a/src/main/java/com/sideproject/shoescream/notification/component/NotificationListener.java
+++ b/src/main/java/com/sideproject/shoescream/notification/component/NotificationListener.java
@@ -16,7 +16,6 @@ public class NotificationListener {
     @TransactionalEventListener
     @Async
     public void handleNotification(NotificationRequest notificationRequest) {
-        notificationService.send(notificationRequest.receiver(), notificationRequest.content(),
-                notificationRequest.relatedUrl(), notificationRequest.notificationType());
+        notificationService.send(notificationRequest);
     }
 }

--- a/src/main/java/com/sideproject/shoescream/notification/dto/request/NotificationRequest.java
+++ b/src/main/java/com/sideproject/shoescream/notification/dto/request/NotificationRequest.java
@@ -6,8 +6,10 @@ import lombok.Builder;
 
 @Builder
 public record NotificationRequest(
+        long domainNumber,
         Member receiver,
         NotificationType notificationType,
         String content,
-        String relatedUrl) {
+        Object object
+) {
 }

--- a/src/main/java/com/sideproject/shoescream/notification/dto/response/NotificationResponse.java
+++ b/src/main/java/com/sideproject/shoescream/notification/dto/response/NotificationResponse.java
@@ -1,24 +1,27 @@
 package com.sideproject.shoescream.notification.dto.response;
 
+import com.sideproject.shoescream.notification.dto.request.NotificationRequest;
 import com.sideproject.shoescream.notification.entity.Notification;
 import lombok.Builder;
 
 @Builder
 public record NotificationResponse(
-        Long id,
+        long notificationNumber,
         String receiver,
         String content,
         String relatedUrl,
-        String type
+        String notificationType,
+        Object object
 ) {
 
-    public static NotificationResponse createNotificationResponse(Notification notification) {
+    public static NotificationResponse createNotificationResponse(Notification notification, NotificationRequest notificationRequest) {
         return NotificationResponse.builder()
-                .id(notification.getNotificationNumber())
+                .notificationNumber(notification.getNotificationNumber())
                 .receiver(notification.getReceiver().getMemberId())
-                .content(notification.getContent())
+                .content(notification.getNotificationContent())
                 .relatedUrl("/test/url")
-                .type(notification.getNotificationType().toString())
+                .notificationType(notification.getNotificationType().toString())
+                .object(notificationRequest.object())
                 .build();
     }
 }

--- a/src/main/java/com/sideproject/shoescream/notification/entity/Notification.java
+++ b/src/main/java/com/sideproject/shoescream/notification/entity/Notification.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @Setter
@@ -20,11 +22,11 @@ public class Notification {
     @Column(name = "notification_number")
     private Long notificationNumber;
 
-    @Column(name = "notification_content")
-    private String content;
+    @Column(name = "domain_number")
+    private Long domainNumber;
 
-    @Column(name = "related_url")
-    private String relatedUrl;
+    @Column(name = "notification_content")
+    private String notificationContent;
 
     @Enumerated(EnumType.STRING)
     private NotificationType notificationType;
@@ -32,6 +34,12 @@ public class Notification {
     @ManyToOne
     @JoinColumn(name = "receiver_number")
     private Member receiver;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "is_read")
+    private boolean isRead;
 
     protected Notification() {
 

--- a/src/main/java/com/sideproject/shoescream/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/sideproject/shoescream/notification/repository/NotificationRepository.java
@@ -2,6 +2,13 @@ package com.sideproject.shoescream.notification.repository;
 
 import com.sideproject.shoescream.notification.entity.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    @Query(value = "select n from Notification n where n.receiver.memberId=:memberId order by n.createdAt desc ")
+    List<Notification> findNotificationsByReceiverIdOrderByCreatedAtDesc(@Param("memberId") String memberId);
 }


### PR DESCRIPTION
#60 에 대한 pr

구현 하다보니 알림은 다양한 domain에서 올수 있으므로 object 타입으로 response를 받아서 전달하였음
위 과정 중 알림 엔티티에서 notificationType과 domainNumber를 통해 domain을 구분하였음

(ex) 실시간 알림 response

```
{
    "resultCode": "SUCCESS",
    "result": {
        "notificationNumber": 1,
        "notificationContent": "결제 알림",
        "notificationType": "PAYMENT",
        "buyerId": "wnsdhqo",
        "createdAt": "2024-06-14T09:38:54.557453",
        "object": {
            "productName": "Nike V2K Run Summit White Metallic Silver",
            "size": "220",
            "price": 96000,
            "quantity": 1,
            "createdAt": "2024-06-14T09:32:42.327902"
        }
    }
}
```