### PR TITLE
입찰-거래-결제 프로세스 상태 점검하기

### DIFF
--- a/src/main/java/com/sideproject/shoescream/bid/util/DealMapper.java
+++ b/src/main/java/com/sideproject/shoescream/bid/util/DealMapper.java
@@ -18,6 +18,21 @@ import java.util.stream.Stream;
 
 public class DealMapper {
 
+    public static Deal toSuccessDeal(Bid bid, long buyerNumber) {
+        LocalDateTime now = LocalDateTime.now();
+        return Deal.builder()
+                .buyerNumber(buyerNumber)
+                .sellerNumber(bid.getMember().getMemberNumber())
+                .product(bid.getProduct())
+                .size(bid.getSize())
+                .price(bid.getBidPrice())
+                .dealStatus(DealStatus.SUCCESS_DEAL)
+                .createdAt(now)
+                .tradedAt(now)
+                .isWriteReview(false)
+                .build();
+    }
+
     public static DealResponse toDealResponse(Deal deal) {
         return DealResponse.builder()
                 .size(deal.getSize())

--- a/src/main/java/com/sideproject/shoescream/pay/controller/KakaoPayController.java
+++ b/src/main/java/com/sideproject/shoescream/pay/controller/KakaoPayController.java
@@ -23,8 +23,8 @@ public class KakaoPayController {
     }
 
     @GetMapping("/success")
-    public ResponseEntity<?> afterPayRequest(@RequestParam("pg_token") String pgToken) {
-        KakaoApproveResponse kakaoApprove = kakaoPayService.approveResponse(pgToken);
+    public ResponseEntity<?> afterPayRequest(@RequestParam("pg_token") String pgToken, @RequestParam("bidNumber") long bidNumber, @RequestParam("memberId") String memberId) {
+        KakaoApproveResponse kakaoApprove = kakaoPayService.approveResponse(pgToken, bidNumber, memberId);
         return new ResponseEntity<>(kakaoApprove, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/sideproject/shoescream/pay/dto/KakaoPayInfoRequest.java
+++ b/src/main/java/com/sideproject/shoescream/pay/dto/KakaoPayInfoRequest.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 @Builder
 public record KakaoPayInfoRequest(
+    long bidNumber,
     String item_name,
     int quantity,
     int total_amount

--- a/src/main/java/com/sideproject/shoescream/pay/service/KakaoPayService.java
+++ b/src/main/java/com/sideproject/shoescream/pay/service/KakaoPayService.java
@@ -1,5 +1,13 @@
 package com.sideproject.shoescream.pay.service;
 
+import com.sideproject.shoescream.bid.entity.Bid;
+import com.sideproject.shoescream.bid.repository.BidRepository;
+import com.sideproject.shoescream.bid.repository.DealRepository;
+import com.sideproject.shoescream.bid.util.DealMapper;
+import com.sideproject.shoescream.global.exception.ErrorCode;
+import com.sideproject.shoescream.member.entity.Member;
+import com.sideproject.shoescream.member.exception.MemberNotFoundException;
+import com.sideproject.shoescream.member.repository.MemberRepository;
 import com.sideproject.shoescream.pay.dto.KakaoApproveResponse;
 import com.sideproject.shoescream.pay.dto.KakaoPayInfoRequest;
 import com.sideproject.shoescream.pay.dto.KakaoReadyResponse;
@@ -17,9 +25,12 @@ import org.springframework.web.client.RestTemplate;
 public class KakaoPayService {
 
     private KakaoReadyResponse kakaoReadyResponse;
+    private final BidRepository bidRepository;
+    private final DealRepository dealRepository;
     private static final String cid = "TC0ONETIME";
     @Value("${pay.key}")
     private String adminKey;
+    private final MemberRepository memberRepository;
 
     public KakaoReadyResponse kakaoPayReady(KakaoPayInfoRequest kakaoPayInfoRequest, String memberId) {
         MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
@@ -31,7 +42,7 @@ public class KakaoPayService {
         parameters.add("total_amount", String.valueOf(kakaoPayInfoRequest.total_amount()));
         parameters.add("vat_amount", "0");
         parameters.add("tax_free_amount", "0");
-        parameters.add("approval_url", "http://localhost:3000/my/history/buying"); // 성공 시 redirect url
+        parameters.add("approval_url", "http://localhost:8080/payment/success?bidNumber=" + kakaoPayInfoRequest.bidNumber() + "&memberId=" + memberId); // 성공 시 redirect url
         parameters.add("cancel_url", "http://localhost:8080/payment/cancel"); // 취소 시 redirect url
         parameters.add("fail_url", "http://localhost:8080/payment/fail"); // 실패 시 redirect url
 
@@ -47,13 +58,14 @@ public class KakaoPayService {
                 KakaoReadyResponse.class);
         return kakaoReadyResponse;
     }
-    public KakaoApproveResponse approveResponse(String pgToken) {
+
+    public KakaoApproveResponse approveResponse(String pgToken, long bidNumber, String memberId) {
 
         // 카카오 요청
         MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
         parameters.add("cid", cid);
         parameters.add("tid", kakaoReadyResponse.tid());
-        parameters.add("partner_order_id", "partner_order_id");
+        parameters.add("partner_order_id", "shoecream:mem:" + memberId);
         parameters.add("partner_user_id", "shoescream");
         parameters.add("pg_token", pgToken);
 
@@ -68,6 +80,9 @@ public class KakaoPayService {
                 requestEntity,
                 KakaoApproveResponse.class);
 
+
+        // Buy_Bid를 삭제하고 -> 거래 완료 db로 저장하는 프로세스 구현
+        completeDeal(memberId, bidNumber);
         return approveResponse;
     }
 
@@ -83,5 +98,14 @@ public class KakaoPayService {
         httpHeaders.set("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
         return httpHeaders;
+    }
+
+    private void completeDeal(String memberId, long bidNumber) {
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+        Bid bid = bidRepository.findById(bidNumber)
+                .orElseThrow(() -> new RuntimeException());
+        dealRepository.save(DealMapper.toSuccessDeal(bid, member.getMemberNumber()));
+        bidRepository.deleteById(bidNumber);
     }
 }


### PR DESCRIPTION
#65 의 내용을 포함하는 pr

카카오 페이 즉시 구매 프로세스에서 결제 완료 시 SUCCESS_DEAL 상태로 거래 DB에 저장하고 입찰 내역의 SELL_BID로 걸린 데이터를 삭제하였음.

TODO:
클라이언트 측에서 카카오 페이 ready 호출을 할 때 어떤 입찰 데이터로 거래를 하는건지 bidNumber를 전달해야 해야함
그러므로 상품 결제 페이지에서 현재 구매하는 상품의 입찰 내역 정보 중 입찰 고유번호를 response해야 함