### PR TITLE
입찰-거래-결제 프로세스 상태 점검하기

### DIFF
--- a/src/main/java/com/sideproject/shoescream/bid/controller/BidController.java
+++ b/src/main/java/com/sideproject/shoescream/bid/controller/BidController.java
@@ -16,8 +16,8 @@ public class BidController {
     private final BidService bidService;
 
     @GetMapping("/buy/{productNumber}")
-    public Response<BuyingProductInfoResponse> getBuyingProductInfo(@PathVariable String productNumber, @RequestParam String size) {
-        return Response.success(bidService.getBuyingProductInfo(productNumber, size));
+    public Response<BuyingProductInfoResponse> getBuyingProductInfo(@PathVariable String productNumber, @RequestParam String size, Authentication authentication) {
+        return Response.success(bidService.getBuyingProductInfo(productNumber, size, authentication.getName()));
     }
 
     @PostMapping("/buy")
@@ -26,8 +26,8 @@ public class BidController {
     }
 
     @GetMapping("/sell/{productNumber}")
-    public Response<SellingProductInfoResponse> getSellingProductInfo(@PathVariable String productNumber, @RequestParam String size) {
-        return Response.success(bidService.getSellingProductInfo(productNumber, size));
+    public Response<SellingProductInfoResponse> getSellingProductInfo(@PathVariable String productNumber, @RequestParam String size, Authentication authentication) {
+        return Response.success(bidService.getSellingProductInfo(productNumber, size, authentication.getName()));
     }
 
     @PostMapping("/sell")

--- a/src/main/java/com/sideproject/shoescream/bid/dto/response/BuyingProductInfoResponse.java
+++ b/src/main/java/com/sideproject/shoescream/bid/dto/response/BuyingProductInfoResponse.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 
 @Builder
 public record BuyingProductInfoResponse(
+        long bidNumber,
+
         String productCode,
 
         String productName,

--- a/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
+++ b/src/main/java/com/sideproject/shoescream/bid/service/BidService.java
@@ -18,12 +18,10 @@ import com.sideproject.shoescream.notification.dto.request.NotificationRequest;
 import com.sideproject.shoescream.product.entity.Product;
 import com.sideproject.shoescream.product.entity.ProductOption;
 import com.sideproject.shoescream.product.exception.ProductNotFoundException;
-import com.sideproject.shoescream.product.repository.ProductImageRepository;
 import com.sideproject.shoescream.product.repository.ProductOptionRepository;
 import com.sideproject.shoescream.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,9 +36,10 @@ public class BidService {
     private final ApplicationEventPublisher eventPublisher;
     private final DealRepository dealRepository;
 
-    public BuyingProductInfoResponse getBuyingProductInfo(String productNumber, String size) {
+    public BuyingProductInfoResponse getBuyingProductInfo(String productNumber, String size, String memberId) {
         ProductOption product = productOptionRepository.findByProduct_ProductNumberAndSize(Long.valueOf(productNumber), size);
-        return BidMapper.toBuyingProductInfoResponse(product);
+        Bid targetBid = bidRepository.findTargetBidOne(Long.valueOf(productNumber), product.getLowestPrice(), product.getSize(), BidType.SELL_BID).get(0);
+        return BidMapper.toBuyingProductInfoResponse(product, targetBid.getBidNumber());
     }
 
     @Transactional
@@ -56,7 +55,7 @@ public class BidService {
     }
 
 
-    public SellingProductInfoResponse getSellingProductInfo(String productNumber, String size) {
+    public SellingProductInfoResponse getSellingProductInfo(String productNumber, String size, String memberId) {
         ProductOption product = productOptionRepository.findByProduct_ProductNumberAndSize(Long.valueOf(productNumber), size);
         return BidMapper.toSellingProductInfoResponse(product);
     }

--- a/src/main/java/com/sideproject/shoescream/bid/util/BidMapper.java
+++ b/src/main/java/com/sideproject/shoescream/bid/util/BidMapper.java
@@ -50,8 +50,9 @@ public class BidMapper {
                 .build();
     }
 
-    public static BuyingProductInfoResponse toBuyingProductInfoResponse(ProductOption productOption) {
+    public static BuyingProductInfoResponse toBuyingProductInfoResponse(ProductOption productOption, long bidNumber) {
         return BuyingProductInfoResponse.builder()
+                .bidNumber(bidNumber)
                 .productCode(productOption.getProduct().getProductCode())
                 .productName(productOption.getProduct().getProductName())
                 .productSubName(productOption.getProduct().getProductSubName())


### PR DESCRIPTION
#65 의 내용을 포함하는 pr

카카오 페이 결제시 주문 상태를 변경하기 위해 구매 페이지에 구매하려는 입찰 내역 고유 번호를 추가하여 적용하였음