### PR TITLE
리뷰 상태 에러 처리 수정

### DIFF
--- a/src/main/java/com/sideproject/shoescream/review/service/ReviewService.java
+++ b/src/main/java/com/sideproject/shoescream/review/service/ReviewService.java
@@ -79,10 +79,6 @@ public class ReviewService {
         Deal deal = dealRepository.findById(reviewPostRequest.dealNumber())
                 .orElseThrow(() -> new RuntimeException());
 
-        //TODO : 거래 DB isWriteReview 기본 값 false로 들어가게 하기 지금 null 이라서 nullexception 뜸
-        if (deal.getIsWriteReview()) {
-            throw new RuntimeException();
-        }
         deal.setIsWriteReview(true);
         Review review = reviewRepository.save(
                 ReviewMapper.toReview(reviewPostRequest, member, product));


### PR DESCRIPTION
THIS
완료된 거래 내역들에 대해서만 리뷰를 작성할 수 있고 리뷰 상태 기본 값으로 False(리뷰 작성 안했음)가 들어간다.
리뷰 작성시 false -> true로 바뀌는데 true값에 대해서 에러 처리를 해놔서 서버 로그에 에러가 계속 떠 에러 처리를 제거 해줬음

is_write_review 상태를 가지고 프론트에서 리뷰 작성 API 접근 처리
